### PR TITLE
Virst version of vercel/otel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,33 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "!*"
+  pull_request:
+
+env:
+  NODE_VERSION: "16"
+  TURBO_REMOTE_ONLY: "true"
+  TURBO_TEAM: "vercel"
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - run: npm i -g pnpm@7.24.2
+      - run: pnpm install
+      - run: pnpm build

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,84 @@
-# otel
+<!--
+PROMPT for GPT-4:
+Write me a README.md for package vercel/otel that helps people get started by setting up their exporter and trace provider for them and false bundles all OPen Telemetry apis in a single package.
+It's not a powerful as using raw APIS, but It should be enough for most cases.
+
+This package exports function `register()` that registers open telemetry provider with a HTTP exporter.
+Register function takes one argument, it's string and it's a service name. It will be used as the app name in many OpenTelemetry backends.
+This package also reexports `@opentelemetry/api` and `@opentelemetry/semantics`.
+
+Use that hip style for Readme that many JS devs use. Keep it concise.
+-->
+
+# 🚀 Vercel Otel
+
+[![npm](https://img.shields.io/npm/v/vercel/otel.svg)](https://www.npmjs.com/package/vercel/otel)
+
+`vercel/otel` is a simple and easy-to-use package that sets up your trace provider and exporter, and bundles all OpenTelemetry APIs in a single package. It's not as powerful as using raw APIs, but it should be enough for most cases.
+
+💡 Use this package to quickly instrument your applications and get started with OpenTelemetry!
+
+## 📦 Installation
+
+```sh
+npm install vercel/otel
+```
+
+## 📚 Usage
+
+```javascript
+const { register, trace } = require("vercel/otel");
+
+// Register the OpenTelemetry provider with an HTTP exporter
+register("your-service-name");
+
+// Now you can use the OpenTelemetry APIs
+const span = trace.getTracer("your-component").startSpan("your-operation");
+```
+
+### 🎨 Customizing your setup
+
+The `register` function takes a single string argument for your service name. This will be used as the app name in many OpenTelemetry backends.
+
+The package also re-exports `@opentelemetry/api` and `@opentelemetry/semantics` for your convenience.
+
+```javascript
+const { context, trace, SemanticAttributes } = require("vercel/otel");
+
+// Use the OpenTelemetry APIs and semantic attributes as needed
+const span = trace.getTracer("your-component").startSpan("your-operation", {
+  attributes: {
+    [SemanticAttributes.HTTP_METHOD]: "GET",
+  },
+});
+
+// Modify the context as needed
+const ctx = trace.setSpan(context.active(), span);
+```
+
+## 📖 API Reference
+
+### `register(serviceName: string)`
+
+Registers the OpenTelemetry provider with an HTTP exporter using the given service name.
+This is all that is needed to trace your app on Vercel.
+
+- `serviceName`: The name of your service, used as the app name in many OpenTelemetry backends.
+
+### Re-exported APIs
+
+This package re-exports the following APIs from `@opentelemetry/api` and `@opentelemetry/semantics`:
+
+- `context`
+- `trace`
+- `SemanticAttributes`
+
+Refer to the official [OpenTelemetry API documentation](https://opentelemetry.io/docs/instrumentation/js/) for details on how to use these APIs.
+
+## 📄 License
+
+[MIT](LICENSE)
+
+---
+
+Made with 💖 by the Vercel. Happy tracing! 📈

--- a/README.md
+++ b/README.md
@@ -36,26 +36,6 @@ register("your-service-name");
 const span = trace.getTracer("your-component").startSpan("your-operation");
 ```
 
-### 🎨 Customizing your setup
-
-The `register` function takes a single string argument for your service name. This will be used as the app name in many OpenTelemetry backends.
-
-The package also re-exports `@opentelemetry/api` and `@opentelemetry/semantics` for your convenience.
-
-```javascript
-const { context, trace, SemanticAttributes } = require("vercel/otel");
-
-// Use the OpenTelemetry APIs and semantic attributes as needed
-const span = trace.getTracer("your-component").startSpan("your-operation", {
-  attributes: {
-    [SemanticAttributes.HTTP_METHOD]: "GET",
-  },
-});
-
-// Modify the context as needed
-const ctx = trace.setSpan(context.active(), span);
-```
-
 ## 📖 API Reference
 
 ### `register(serviceName: string)`
@@ -67,13 +47,7 @@ This is all that is needed to trace your app on Vercel.
 
 ### Re-exported APIs
 
-This package re-exports the following APIs from `@opentelemetry/api` and `@opentelemetry/semantics`:
-
-- `context`
-- `trace`
-- `SemanticAttributes`
-
-Refer to the official [OpenTelemetry API documentation](https://opentelemetry.io/docs/instrumentation/js/) for details on how to use these APIs.
+This package re-exports everything from `@opentelemetry/api`. Refer to the official [OpenTelemetry API documentation](https://opentelemetry.io/docs/instrumentation/js/) for details on how to use these APIs.
 
 ## 📄 License
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,61 @@
+{
+  "name": "@vercel/otel",
+  "version": "0.0.1",
+  "description": "Vercel wrapper around OpenTelemetry APIs",
+  "exports": {
+    ".": {
+      "edge": {
+        "types": "./dist/index.edge.d.ts",
+        "default": "./dist/index.edge.js"
+      },
+      "edge-light": {
+        "types": "./dist/index.edge.d.ts",
+        "default": "./dist/index.edge.js"
+      },
+      "browser": {
+        "types": "./dist/index.browser.d.ts",
+        "default": "./dist/index.browser.js"
+      },
+      "worker": {
+        "types": "./dist/index.edge.d.ts",
+        "default": "./dist/index.edge.js"
+      },
+      "workerd": {
+        "types": "./dist/index.edge.d.ts",
+        "default": "./dist/index.edge.js"
+      },
+      "import": {
+        "types": "./dist/index.node.d.ts",
+        "default": "./dist/index.node.js"
+      },
+      "node": {
+        "types": "./dist/index.node.d.ts",
+        "default": "./dist/index.node.js"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vercel/vercel.git",
+    "directory": "packages/otel"
+  },
+  "scripts": {
+    "build": "pnpm build:node",
+    "build:node": "tsc --project tsconfig.node.json",
+    "build:edge": "tsc --project tsconfig.edge.json",
+    "build:browser": "tsc --project tsconfig.browser.json"
+  },
+  "license": "MIT",
+  "devDependencies": {
+    "@types/node": "14.18.33",
+    "typescript": "^4.8.4"
+  },
+  "dependencies": {
+    "@opentelemetry/api": "1.4.1",
+    "@opentelemetry/exporter-trace-otlp-http": "0.35.1",
+    "@opentelemetry/resources": "1.9.1",
+    "@opentelemetry/sdk-trace-node": "1.9.1",
+    "@opentelemetry/semantic-conventions": "1.9.1"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -13,10 +13,6 @@
         "types": "./dist/index.edge.d.ts",
         "default": "./dist/index.edge.js"
       },
-      "browser": {
-        "types": "./dist/index.browser.d.ts",
-        "default": "./dist/index.browser.js"
-      },
       "worker": {
         "types": "./dist/index.edge.d.ts",
         "default": "./dist/index.edge.js"
@@ -42,10 +38,9 @@
     "directory": "packages/otel"
   },
   "scripts": {
-    "build": "pnpm build:node && pnpm build:edge && pnpm build:browser",
+    "build": "pnpm build:node && pnpm build:edge",
     "build:node": "tsc --project tsconfig.node.json",
-    "build:edge": "tsc --project tsconfig.edge.json",
-    "build:browser": "tsc --project tsconfig.browser.json"
+    "build:edge": "tsc --project tsconfig.edge.json"
   },
   "license": "MIT",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@vercel/otel",
   "version": "0.0.1",
   "description": "Vercel wrapper around OpenTelemetry APIs",
+  "types": "./dist/index.node.d.ts",
   "exports": {
     ".": {
       "edge": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "directory": "packages/otel"
   },
   "scripts": {
-    "build": "pnpm build:node",
+    "build": "pnpm build:node && pnpm build:edge && pnpm build:browser",
     "build:node": "tsc --project tsconfig.node.json",
     "build:edge": "tsc --project tsconfig.edge.json",
     "build:browser": "tsc --project tsconfig.browser.json"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,192 @@
+lockfileVersion: 5.4
+
+specifiers:
+  '@opentelemetry/api': 1.4.1
+  '@opentelemetry/exporter-trace-otlp-http': 0.35.1
+  '@opentelemetry/resources': 1.9.1
+  '@opentelemetry/sdk-trace-node': 1.9.1
+  '@opentelemetry/semantic-conventions': 1.9.1
+  '@types/node': 14.18.33
+  typescript: ^4.8.4
+
+dependencies:
+  '@opentelemetry/api': 1.4.1
+  '@opentelemetry/exporter-trace-otlp-http': 0.35.1_@opentelemetry+api@1.4.1
+  '@opentelemetry/resources': 1.9.1_@opentelemetry+api@1.4.1
+  '@opentelemetry/sdk-trace-node': 1.9.1_@opentelemetry+api@1.4.1
+  '@opentelemetry/semantic-conventions': 1.9.1
+
+devDependencies:
+  '@types/node': 14.18.33
+  typescript: 4.9.5
+
+packages:
+
+  /@opentelemetry/api/1.4.1:
+    resolution: {integrity: sha512-O2yRJce1GOc6PAy3QxFM4NzFiWzvScDC1/5ihYBL6BUEVdq0XMWN01sppE+H6bBXbaFYipjwFLEWLg5PaSOThA==}
+    engines: {node: '>=8.0.0'}
+    dev: false
+
+  /@opentelemetry/context-async-hooks/1.9.1_@opentelemetry+api@1.4.1:
+    resolution: {integrity: sha512-HmycxnnIm00gdmxfD5OkDotL15bGqazLYqQJdcv1uNt22OSc5F/a3Paz3yznmf+/gWdPG8nlq/zd9H0mNXJnGg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.5.0'
+    dependencies:
+      '@opentelemetry/api': 1.4.1
+    dev: false
+
+  /@opentelemetry/core/1.9.1_@opentelemetry+api@1.4.1:
+    resolution: {integrity: sha512-6/qon6tw2I8ZaJnHAQUUn4BqhTbTNRS0WP8/bA0ynaX+Uzp/DDbd0NS0Cq6TMlh8+mrlsyqDE7mO50nmv2Yvlg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.5.0'
+    dependencies:
+      '@opentelemetry/api': 1.4.1
+      '@opentelemetry/semantic-conventions': 1.9.1
+    dev: false
+
+  /@opentelemetry/exporter-trace-otlp-http/0.35.1_@opentelemetry+api@1.4.1:
+    resolution: {integrity: sha512-EJgAsrvscKsqb/GzF1zS74vM+Z/aQRhrFE7hs/1GK1M9bLixaVyMGwg2pxz1wdYdjxS1mqpHMhXU+VvMvFCw1w==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+    dependencies:
+      '@opentelemetry/api': 1.4.1
+      '@opentelemetry/core': 1.9.1_@opentelemetry+api@1.4.1
+      '@opentelemetry/otlp-exporter-base': 0.35.1_@opentelemetry+api@1.4.1
+      '@opentelemetry/otlp-transformer': 0.35.1_@opentelemetry+api@1.4.1
+      '@opentelemetry/resources': 1.9.1_@opentelemetry+api@1.4.1
+      '@opentelemetry/sdk-trace-base': 1.9.1_@opentelemetry+api@1.4.1
+    dev: false
+
+  /@opentelemetry/otlp-exporter-base/0.35.1_@opentelemetry+api@1.4.1:
+    resolution: {integrity: sha512-Sc0buJIs8CfUeQCL/12vDDjBREgsqHdjboBa/kPQDgMf008OBJSM02Ijj6T1TH+QVHl/VHBBEVJF+FTf0EH9Vg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+    dependencies:
+      '@opentelemetry/api': 1.4.1
+      '@opentelemetry/core': 1.9.1_@opentelemetry+api@1.4.1
+    dev: false
+
+  /@opentelemetry/otlp-transformer/0.35.1_@opentelemetry+api@1.4.1:
+    resolution: {integrity: sha512-c0HXcJ49MKoWSaA49J8PXlVx48CeEFpL0odP6KBkVT+Bw6kAe8JlI3mIezyN05VCDJGtS2I5E6WEsE+DJL1t9A==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.5.0'
+    dependencies:
+      '@opentelemetry/api': 1.4.1
+      '@opentelemetry/core': 1.9.1_@opentelemetry+api@1.4.1
+      '@opentelemetry/resources': 1.9.1_@opentelemetry+api@1.4.1
+      '@opentelemetry/sdk-metrics': 1.9.1_@opentelemetry+api@1.4.1
+      '@opentelemetry/sdk-trace-base': 1.9.1_@opentelemetry+api@1.4.1
+    dev: false
+
+  /@opentelemetry/propagator-b3/1.9.1_@opentelemetry+api@1.4.1:
+    resolution: {integrity: sha512-V+/ufHnZSr0YlbNhPg4PIQAZOhP61fVwL0JZJ6qnl9i0jgaZBSAtV99ZvHMxMy0Z1tf+oGj1Hk+S6jRRXL+j1Q==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.5.0'
+    dependencies:
+      '@opentelemetry/api': 1.4.1
+      '@opentelemetry/core': 1.9.1_@opentelemetry+api@1.4.1
+    dev: false
+
+  /@opentelemetry/propagator-jaeger/1.9.1_@opentelemetry+api@1.4.1:
+    resolution: {integrity: sha512-xjG5HnOgu/1f9+GphWr8lqxaU51iFL9HgFdnSQBSFqhM2OeMuzpFt6jmkpZJBAK3oqQ9BG52fHfCdYlw3GOkVQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.5.0'
+    dependencies:
+      '@opentelemetry/api': 1.4.1
+      '@opentelemetry/core': 1.9.1_@opentelemetry+api@1.4.1
+    dev: false
+
+  /@opentelemetry/resources/1.9.1_@opentelemetry+api@1.4.1:
+    resolution: {integrity: sha512-VqBGbnAfubI+l+yrtYxeLyOoL358JK57btPMJDd3TCOV3mV5TNBmzvOfmesM4NeTyXuGJByd3XvOHvFezLn3rQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.5.0'
+    dependencies:
+      '@opentelemetry/api': 1.4.1
+      '@opentelemetry/core': 1.9.1_@opentelemetry+api@1.4.1
+      '@opentelemetry/semantic-conventions': 1.9.1
+    dev: false
+
+  /@opentelemetry/sdk-metrics/1.9.1_@opentelemetry+api@1.4.1:
+    resolution: {integrity: sha512-AyhKDcA8NuV7o1+9KvzRMxNbATJ8AcrutKilJ6hWSo9R5utnzxgffV4y+Hp4mJn84iXxkv+CBb99GOJ2A5OMzA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.5.0'
+    dependencies:
+      '@opentelemetry/api': 1.4.1
+      '@opentelemetry/core': 1.9.1_@opentelemetry+api@1.4.1
+      '@opentelemetry/resources': 1.9.1_@opentelemetry+api@1.4.1
+      lodash.merge: 4.6.2
+    dev: false
+
+  /@opentelemetry/sdk-trace-base/1.9.1_@opentelemetry+api@1.4.1:
+    resolution: {integrity: sha512-Y9gC5M1efhDLYHeeo2MWcDDMmR40z6QpqcWnPCm4Dmh+RHAMf4dnEBBntIe1dDpor686kyU6JV1D29ih1lZpsQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.5.0'
+    dependencies:
+      '@opentelemetry/api': 1.4.1
+      '@opentelemetry/core': 1.9.1_@opentelemetry+api@1.4.1
+      '@opentelemetry/resources': 1.9.1_@opentelemetry+api@1.4.1
+      '@opentelemetry/semantic-conventions': 1.9.1
+    dev: false
+
+  /@opentelemetry/sdk-trace-node/1.9.1_@opentelemetry+api@1.4.1:
+    resolution: {integrity: sha512-wwwCM2G/A0LY3oPLDyO31uRnm9EMNkhhjSxL9cmkK2kM+F915em8K0pXkPWFNGWu0OHkGALWYwH6Oz0P5nVcHA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.5.0'
+    dependencies:
+      '@opentelemetry/api': 1.4.1
+      '@opentelemetry/context-async-hooks': 1.9.1_@opentelemetry+api@1.4.1
+      '@opentelemetry/core': 1.9.1_@opentelemetry+api@1.4.1
+      '@opentelemetry/propagator-b3': 1.9.1_@opentelemetry+api@1.4.1
+      '@opentelemetry/propagator-jaeger': 1.9.1_@opentelemetry+api@1.4.1
+      '@opentelemetry/sdk-trace-base': 1.9.1_@opentelemetry+api@1.4.1
+      semver: 7.3.8
+    dev: false
+
+  /@opentelemetry/semantic-conventions/1.9.1:
+    resolution: {integrity: sha512-oPQdbFDmZvjXk5ZDoBGXG8B4tSB/qW5vQunJWQMFUBp7Xe8O1ByPANueJ+Jzg58esEBegyyxZ7LRmfJr7kFcFg==}
+    engines: {node: '>=14'}
+    dev: false
+
+  /@types/node/14.18.33:
+    resolution: {integrity: sha512-qelS/Ra6sacc4loe/3MSjXNL1dNQ/GjxNHVzuChwMfmk7HuycRLVQN2qNY3XahK+fZc5E2szqQSKUyAF0E+2bg==}
+    dev: true
+
+  /lodash.merge/4.6.2:
+    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+    dev: false
+
+  /lru-cache/6.0.0:
+    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
+    engines: {node: '>=10'}
+    dependencies:
+      yallist: 4.0.0
+    dev: false
+
+  /semver/7.3.8:
+    resolution: {integrity: sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      lru-cache: 6.0.0
+    dev: false
+
+  /typescript/4.9.5:
+    resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
+    engines: {node: '>=4.2.0'}
+    hasBin: true
+    dev: true
+
+  /yallist/4.0.0:
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+    dev: false

--- a/src/index.browser.ts
+++ b/src/index.browser.ts
@@ -1,0 +1,4 @@
+export const register = (serviceName: string) => {
+  void serviceName;
+  // We don't support OpenTelemetry on client-side yet.
+};

--- a/src/index.browser.ts
+++ b/src/index.browser.ts
@@ -1,4 +1,0 @@
-export const registerOTel = (serviceName: string) => {
-  void serviceName;
-  // We don't support OpenTelemetry on client-side yet.
-};

--- a/src/index.browser.ts
+++ b/src/index.browser.ts
@@ -1,4 +1,4 @@
-export const register = (serviceName: string) => {
+export const registerOTel = (serviceName: string) => {
   void serviceName;
   // We don't support OpenTelemetry on client-side yet.
 };

--- a/src/index.edge.ts
+++ b/src/index.edge.ts
@@ -1,0 +1,4 @@
+export const register = (serviceName: string) => {
+  void serviceName;
+  // We don't support OpenTelemetry on edge.
+};

--- a/src/index.edge.ts
+++ b/src/index.edge.ts
@@ -1,4 +1,4 @@
-export const register = (serviceName: string) => {
+export const registerOTel = (serviceName: string) => {
   void serviceName;
   // We don't support OpenTelemetry on edge.
 };

--- a/src/index.node.ts
+++ b/src/index.node.ts
@@ -1,5 +1,4 @@
 export * from "@opentelemetry/api";
-export * from "@opentelemetry/semantic-conventions";
 
 import { Resource } from "@opentelemetry/resources";
 import { SemanticResourceAttributes } from "@opentelemetry/semantic-conventions";

--- a/src/index.node.ts
+++ b/src/index.node.ts
@@ -1,16 +1,16 @@
-export * from '@opentelemetry/api';
-export * from '@opentelemetry/semantic-conventions';
+export * from "@opentelemetry/api";
+export * from "@opentelemetry/semantic-conventions";
 
-import { Resource } from '@opentelemetry/resources';
-import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
+import { Resource } from "@opentelemetry/resources";
+import { SemanticResourceAttributes } from "@opentelemetry/semantic-conventions";
 import {
   NodeTracerProvider,
   SimpleSpanProcessor,
-} from '@opentelemetry/sdk-trace-node';
+} from "@opentelemetry/sdk-trace-node";
 
-import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
 
-export const register = (serviceName: string) => {
+export const registerOTel = (serviceName: string) => {
   const provider = new NodeTracerProvider({
     resource: new Resource({
       [SemanticResourceAttributes.SERVICE_NAME]: serviceName,

--- a/src/index.node.ts
+++ b/src/index.node.ts
@@ -1,0 +1,25 @@
+export * from '@opentelemetry/api';
+export * from '@opentelemetry/semantic-conventions';
+
+import { Resource } from '@opentelemetry/resources';
+import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
+import {
+  NodeTracerProvider,
+  SimpleSpanProcessor,
+} from '@opentelemetry/sdk-trace-node';
+
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
+
+export const register = (serviceName: string) => {
+  const provider = new NodeTracerProvider({
+    resource: new Resource({
+      [SemanticResourceAttributes.SERVICE_NAME]: serviceName,
+    }),
+  });
+
+  provider.register();
+
+  provider.addSpanProcessor(new SimpleSpanProcessor(new OTLPTraceExporter({})));
+
+  return provider;
+};

--- a/tsconfig.browser.json
+++ b/tsconfig.browser.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "files": ["./src/index.edge.ts"]
+}

--- a/tsconfig.browser.json
+++ b/tsconfig.browser.json
@@ -1,4 +1,7 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "lib": ["ES2020", "dom"]
+  },
   "files": ["./src/index.edge.ts"]
 }

--- a/tsconfig.edge.json
+++ b/tsconfig.edge.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "files": ["./src/index.edge.ts"]
+}

--- a/tsconfig.edge.json
+++ b/tsconfig.edge.json
@@ -1,4 +1,7 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "lib": ["ES2020", "dom"]
+  },
   "files": ["./src/index.edge.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "esModuleInterop": true,
+    "lib": ["ES2020"],
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "noEmitOnError": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitReturns": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "outDir": "./dist",
+    "types": ["node"],
+    "strict": true,
+    "sourceMap": true,
+    "target": "ES2020"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    // There is a bug in OTEL that requires us to add dom types: https://github.com/open-telemetry/opentelemetry-js/issues/3580
+    "lib": ["ES2020", "dom"]
+  },
+  "files": ["./src/index.node.ts"]
+}


### PR DESCRIPTION
Create a small wrapper around otel APIs that will make deploying next.js instrumented with otel seamless.

The biggest issue is that some dependencies are node only right now, so we provide just an empty functions when used in edge. So that customers don't need to conditional require otel APIs only in node.
