### PR TITLE
gaspar/coallesce http route operations

### DIFF
--- a/packages/otel/src/processor/composite-span-processor.ts
+++ b/packages/otel/src/processor/composite-span-processor.ts
@@ -157,6 +157,18 @@ function getResourceAttributes(span: ReadableSpan): Attributes | undefined {
   // the default operation.name is "library name + span kind".
   const libraryName = span.instrumentationLibrary.name;
 
+  if (
+    httpMethod &&
+    httpRoute &&
+    typeof httpMethod === "string" &&
+    typeof httpRoute === "string"
+  ) {
+    return {
+      "operation.name": "http",
+      "resource.name": resourceName ?? httpRoute,
+    };
+  }
+
   const spanType = nextSpanType ?? spanTypeAttr;
   if (spanType && typeof spanType === "string") {
     const nextOperationName = toOperationName(libraryName, spanType);
@@ -167,21 +179,6 @@ function getResourceAttributes(span: ReadableSpan): Attributes | undefined {
       };
     }
     return { "operation.name": nextOperationName };
-  }
-
-  if (
-    httpMethod &&
-    httpRoute &&
-    typeof httpMethod === "string" &&
-    typeof httpRoute === "string"
-  ) {
-    return {
-      "operation.name": toOperationName(
-        libraryName,
-        `http.${SPAN_KIND_NAME[kind] || "internal"}.${httpMethod}`
-      ),
-      "resource.name": resourceName ?? httpRoute,
-    };
   }
 
   return {


### PR DESCRIPTION
**Coallesce http route operations under 'http'**

Follows pattern on 

https://github.com/vercel/front/blob/b8b3f8337fead9029a7d35aad4ad5250757f1007/packages/otel/src/util/server-span-processor.ts#L93-L107