### PR TITLE
Fix typo resource.name

### DIFF
--- a/packages/otel/src/processor/composite-span-processor.ts
+++ b/packages/otel/src/processor/composite-span-processor.ts
@@ -150,7 +150,7 @@ function getResourceAttributes(span: ReadableSpan): Attributes | undefined {
   const { kind, attributes } = span;
   const {
     "operation.name": operationName,
-    "resouce.name": resourceName,
+    "resource.name": resourceName,
     "span.type": spanTypeAttr,
     "next.span_type": nextSpanType,
     "http.method": httpMethod,


### PR DESCRIPTION
### Fix typo resource.name

`resouce.name` => `resource.name`