### PR TITLE
feat(otel): add deployment ID resource attribute

### DIFF
--- a/.changeset/calm-geese-peel.md
+++ b/.changeset/calm-geese-peel.md
@@ -1,0 +1,5 @@
+---
+"@vercel/otel": minor
+---
+
+Set vercel.deployment_id as a resource attribute

--- a/packages/otel/src/sdk.ts
+++ b/packages/otel/src/sdk.ts
@@ -117,6 +117,9 @@ export class Sdk {
           process.env.VERCEL_BRANCH_URL ||
           process.env.NEXT_PUBLIC_VERCEL_BRANCH_URL ||
           undefined,
+        "vercel.deployment_id":
+          process.env.VERCEL_DEPLOYMENT_ID ||
+          undefined,
         [SemanticResourceAttributes.SERVICE_VERSION]: process.env.VERCEL_DEPLOYMENT_ID,
 
         ...configuration.attributes,

--- a/packages/otel/src/types.ts
+++ b/packages/otel/src/types.ts
@@ -73,6 +73,7 @@ export interface Configuration {
    * - `vercel.sha` - the Vercel deployment Git SHA (`VERCEL_GIT_COMMIT_SHA` environment variable).
    * - `vercel.host` - the Vercel deployment host for the Git SHA (`VERCEL_URL` environment variable).
    * - `vercel.branch_host` - the Vercel deployment host for the branch (`VERCEL_BRANCH_URL` environment variable).
+   * - `vercel.deployment_id` - the Vercel deployment ID (`VERCEL_DEPLOYMENT_ID` environment variable).
    *
    * Any additional attributes will be merged with the default attributes.
    */


### PR DESCRIPTION
# Why
Through log drain's `deploymentId` field it is possible to link log records to a specific Vercel deployment.

It would be great if the same level of linking could be established for OTLP data on Vercel. If that were the case, OTLP and log drain information could be correlated to the same "resource" (in OpenTelemetry terminology).

# What
Report `vercel.deployment_id` as a resource attribute.