### PR TITLE
packages/otel: set the default service version to vercel_deployment_id

### DIFF
--- a/packages/otel/src/sdk.ts
+++ b/packages/otel/src/sdk.ts
@@ -61,7 +61,7 @@ export class Sdk {
   private meterProvider: MeterProvider | undefined;
   private disableInstrumentations: (() => void) | undefined;
 
-  public constructor(private configuration: Configuration = {}) {}
+  public constructor(private configuration: Configuration = {}) { }
 
   public start(): void {
     const env = getEnv();
@@ -117,6 +117,7 @@ export class Sdk {
           process.env.VERCEL_BRANCH_URL ||
           process.env.NEXT_PUBLIC_VERCEL_BRANCH_URL ||
           undefined,
+        [SemanticResourceAttributes.SERVICE_VERSION]: process.env.VERCEL_DEPLOYMENT_ID,
 
         ...configuration.attributes,
       })


### PR DESCRIPTION
This allows grouping by vercel deployments in providers like DataDog.