### PR TITLE
Use OpenTelemetry semantic convention attribute keys instead of custom vercel.* attribute keys

### DIFF
--- a/.changeset/wild-badgers-kneel.md
+++ b/.changeset/wild-badgers-kneel.md
@@ -1,0 +1,19 @@
+---
+"@vercel/otel": major
+---
+
+Use OpenTelemetry semantic convention attribute keys instead of custom vercel.\* attribute keys. This change is backward
+incompatible. The following attribute keys have been changed:
+
+Resource attributes:
+ - `env` -> `deployment.environment`
+ - `vercel.region` -> `cloud.region`
+ - `vercel.runtime` -> `process.runtime.name`
+ - `vercel.sha` -> `vcs.repository.ref.revision`
+
+Span attributes:
+ - `vercel.request_id` -> `faas.invocation_id`
+ - `vercel.edge_region` -> `faas.invoked_region`
+
+Furthermore, the following new resource attributes have been added:
+ - `cloud.provider=vercel`

--- a/packages/otel/src/sdk.ts
+++ b/packages/otel/src/sdk.ts
@@ -103,10 +103,14 @@ export class Sdk {
         // Vercel.
         // https://vercel.com/docs/projects/environment-variables/system-environment-variables
         // Vercel Env set as top level attribute for simplicity. One of 'production', 'preview' or 'development'.
-        env: process.env.VERCEL_ENV || process.env.NEXT_PUBLIC_VERCEL_ENV,
-        "vercel.region": process.env.VERCEL_REGION,
-        "vercel.runtime": runtime,
-        "vercel.sha":
+        [SemanticResourceAttributes.DEPLOYMENT_ENVIRONMENT]: process.env.VERCEL_ENV || process.env.NEXT_PUBLIC_VERCEL_ENV,
+        [SemanticResourceAttributes.CLOUD_REGION]: process.env.VERCEL_REGION,
+        [SemanticResourceAttributes.CLOUD_PROVIDER]: "vercel",
+        [SemanticResourceAttributes.PROCESS_RUNTIME_NAME]: runtime,
+        // This semantic resource attribute is not yet part of the semantic conventions package we are using, but it
+        // exists within the specification.
+        // https://github.com/open-telemetry/semantic-conventions/blob/b6793e2df75446a9f1c3e459deccc801fa512342/model/registry/vcs.yaml#L43C13-L43C40
+        "vcs.repository.ref.revision":
           process.env.VERCEL_GIT_COMMIT_SHA ||
           process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA,
         "vercel.host":

--- a/packages/otel/src/types.ts
+++ b/packages/otel/src/types.ts
@@ -67,10 +67,11 @@ export interface Configuration {
    * including:
    * - `service.name` - the service name.
    * - `node.env` - the value of `NODE_ENV` environment variable.
-   * - `env` - the Vercel deployment environment such as "production" or "preview" (`VERCEL_ENV` environment variable).
-   * - `vercel.region` - the Vercel deployment region (`VERCEL_REGION` environment variable).
-   * - `vercel.runtime` - "nodejs" or "edge" (`NEXT_RUNTIME` environment variable).
-   * - `vercel.sha` - the Vercel deployment Git SHA (`VERCEL_GIT_COMMIT_SHA` environment variable).
+   * - `deployment.environment` - the Vercel deployment environment such as "production" or "preview" (`VERCEL_ENV` environment variable).
+   * - `cloud.region` - the Vercel deployment region (`VERCEL_REGION` environment variable).
+   * - `cloud.provider` - set to `vercel`
+   * - `process.runtime.name` - "nodejs" or "edge" (`NEXT_RUNTIME` environment variable).
+   * - `vcs.repository.ref.revision` - the Vercel deployment Git SHA (`VERCEL_GIT_COMMIT_SHA` environment variable).
    * - `vercel.host` - the Vercel deployment host for the Git SHA (`VERCEL_URL` environment variable).
    * - `vercel.branch_host` - the Vercel deployment host for the branch (`VERCEL_BRANCH_URL` environment variable).
    *

--- a/packages/otel/src/vercel-request-context/attributes.ts
+++ b/packages/otel/src/vercel-request-context/attributes.ts
@@ -24,9 +24,12 @@ export function getVercelRequestContextAttributes(
     [SemanticAttributes.HTTP_USER_AGENT]: context.headers["user-agent"],
     "http.referer": context.headers.referer,
 
-    "vercel.request_id": parseRequestId(context.headers["x-vercel-id"]),
+    // This semantic span attribute is not yet part of the semantic conventions package we are using, but it
+    // exists within the specification.
+    // https://opentelemetry.io/docs/specs/semconv/attributes-registry/faas/
+    "faas.invocation_id": parseRequestId(context.headers["x-vercel-id"]),
     "vercel.matched_path": context.headers["x-matched-path"],
-    "vercel.edge_region": context.headers["x-vercel-edge-region"],
+    [SemanticAttributes.FAAS_INVOKED_REGION]: context.headers["x-vercel-edge-region"],
 
     ...rootAttrs,
   });


### PR DESCRIPTION
Addresses the points brought forth in https://github.com/vercel/otel/issues/103.

Note the changeset, where I describe the changes made.