### PR TITLE
Adding repository info to the `package.json`

### DIFF
--- a/packages/otel/package.json
+++ b/packages/otel/package.json
@@ -6,6 +6,11 @@
     "access": "public"
   },
   "description": "Vercel wrapper around OpenTelemetry APIs",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vercel/otel",
+    "directory": "packages/otel"
+  },
   "author": "Vercel Inc",
   "license": "MIT",
   "sideEffects": false,


### PR DESCRIPTION
Makes it a little easier for someone who wants to have a look at the source via the package.