### PR TITLE
Set default service name to unknown_service:node

### DIFF
--- a/packages/otel/src/sdk.ts
+++ b/packages/otel/src/sdk.ts
@@ -91,7 +91,7 @@ export class Sdk {
     this.contextManager = contextManager;
 
     const serviceName =
-      env.OTEL_SERVICE_NAME || configuration.serviceName || "app";
+      env.OTEL_SERVICE_NAME || configuration.serviceName || "unknown_service:node";
     let resource = new Resource(
       omitUndefinedAttributes({
         [SemanticResourceAttributes.SERVICE_NAME]: serviceName,


### PR DESCRIPTION
As per https://opentelemetry.io/docs/specs/semconv/resource/#service the service name should fallback to a specific name