### PR TITLE
Fix semvers of otel's peer dependencies

### DIFF
--- a/packages/otel/package.json
+++ b/packages/otel/package.json
@@ -91,10 +91,10 @@
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.7.0",
-    "@opentelemetry/api-logs": ">=0.46.0 && <1.0.0",
-    "@opentelemetry/instrumentation": ">=0.46.0 && <1.0.0",
+    "@opentelemetry/api-logs": ">=0.46.0 <1.0.0",
+    "@opentelemetry/instrumentation": ">=0.46.0 <1.0.0",
     "@opentelemetry/resources": "^1.19.0",
-    "@opentelemetry/sdk-logs": ">=0.46.0 && <1.0.0",
+    "@opentelemetry/sdk-logs": ">=0.46.0 <1.0.0",
     "@opentelemetry/sdk-metrics": "^1.19.0",
     "@opentelemetry/sdk-trace-base": "^1.19.0"
   }


### PR DESCRIPTION
`&&` is not a valid token in the semver requirement - see https://github.com/npm/node-semver/?tab=readme-ov-file#range-grammar. && is implicit and implied.

Although this works with most package manages because they run in loose mode and discard invalid tokens, installation fails when running on Deno because it enforces version range specifiers to strictly conform to the grammar.

When running `deno install` the following error is thrown:
```
error: Error in @vercel/otel@1.10.0 parsing version requirement for dependency "@opentelemetry/api-logs": ">=0.46.0 && <1.0.0"

Caused by:
    0: Invalid version requirement
    1: Unexpected character.
         >=0.46.0 && <1.0.0
         ~
```

See https://github.com/denoland/deno/issues/26168 for related issue.