### PR TITLE
[vercel/otel] update install step

### DIFF
--- a/packages/otel/README.md
+++ b/packages/otel/README.md
@@ -9,7 +9,7 @@
 ## 📦 Installation
 
 ```sh
-npm install @vercel/otel @opentelemetry/api @opentelemetry/api-logs @opentelemetry/instrumentation @opentelemetry/resources @opentelemetry/sdk-logs @opentelemetry/sdk
+npm install @vercel/otel @opentelemetry/api @opentelemetry/api-logs
 ```
 
 ## 📚 Usage

--- a/packages/otel/README.md
+++ b/packages/otel/README.md
@@ -9,7 +9,7 @@
 ## 📦 Installation
 
 ```sh
-npm install @vercel/otel
+npm install @vercel/otel @opentelemetry/api @opentelemetry/api-logs @opentelemetry/instrumentation @opentelemetry/resources @opentelemetry/sdk-logs @opentelemetry/sdk
 ```
 
 ## 📚 Usage


### PR DESCRIPTION
`@verce/otel` has a couple of peer dependencies which needs to be installed and were missing in the docs.