### PR TITLE
Use VERCEL_REGION system env var instead of reading internal header

### DIFF
--- a/.changeset/olive-dodos-melt.md
+++ b/.changeset/olive-dodos-melt.md
@@ -1,0 +1,5 @@
+---
+"@vercel/otel": patch
+---
+
+Use VERCEL_REGION system env var instead of reading internal header

--- a/packages/otel/src/vercel-request-context/attributes.ts
+++ b/packages/otel/src/vercel-request-context/attributes.ts
@@ -26,7 +26,7 @@ export function getVercelRequestContextAttributes(
 
     "vercel.request_id": parseRequestId(context.headers["x-vercel-id"]),
     "vercel.matched_path": context.headers["x-matched-path"],
-    "vercel.edge_region": context.headers["x-vercel-edge-region"],
+    "vercel.edge_region": process.env.VERCEL_REGION,
 
     ...rootAttrs,
   });


### PR DESCRIPTION
`x-vercel-edge-region` is an undocumented internal header, which we're going to deprecate soon. Edge Middleware/Functions have the same access for the `process.env.VERCEL_REGION` system env var that returns its execution region.