### PR TITLE
Fix FormData handling in fetch instrumentation

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,7 +7,13 @@
   "access": "restricted",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["e2e", "sample", "bridge-emulator", "collector"],
+  "ignore": [
+    "e2e",
+    "sample",
+    "bridge-emulator",
+    "collector",
+    "multiple-exporters"
+  ],
   "snapshot": {
     "useCalculatedVersion": true
   }

--- a/.changeset/twelve-items-sell.md
+++ b/.changeset/twelve-items-sell.md
@@ -1,0 +1,5 @@
+---
+"@vercel/otel": patch
+---
+
+Fix FormData in fetch instrumentation

--- a/apps/sample/app/api/service/service.ts
+++ b/apps/sample/app/api/service/service.ts
@@ -16,9 +16,20 @@ export function runService(request: Request): Promise<string> {
         return "<no data>";
       }
 
+      let body: BodyInit | null = null;
+      const isFormData = url.searchParams.get("mode") === "formdata";
+      if (isFormData) {
+        const fd = new FormData();
+        fd.set("cmd", "echo");
+        fd.set("data.foo", "bar");
+        body = fd;
+      } else {
+        body = JSON.stringify({ cmd: "echo", data: { foo: "bar" } });
+      }
+
       const response = await fetch(dataUrl, {
         method: "POST",
-        body: JSON.stringify({ cmd: "echo", data: { foo: "bar" } }),
+        body,
         headers: { "X-Cmd": "echo" },
         cache: "no-store",
       });

--- a/packages/bridge-emulator/package.json
+++ b/packages/bridge-emulator/package.json
@@ -28,6 +28,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "formidable": "3.5.2",
     "next": "14.2.1-canary.7"
   },
   "peerDependencies": {
@@ -35,10 +36,11 @@
     "@vercel/otel": "workspace:^"
   },
   "devDependencies": {
+    "@types/formidable": "3.4.5",
     "@types/node": "^20",
     "@vercel/otel": "workspace:^",
     "eslint-config": "workspace:*",
-    "typescript-config": "workspace:*",
-    "typescript": "^5"
+    "typescript": "^5",
+    "typescript-config": "workspace:*"
   }
 }

--- a/packages/bridge-emulator/src/client/index.ts
+++ b/packages/bridge-emulator/src/client/index.ts
@@ -102,7 +102,9 @@ class BridgeEmulatorServer implements Bridge {
         const waiting = this.waitingAck.get(json.testId);
         if (waiting) {
           waiting.finally(() => {
-            this.waitingAck.delete(json.testId);
+            if ("testId" in json) {
+              this.waitingAck.delete(json.testId);
+            }
             res.writeHead(200, "OK", { "X-Server": "bridge" });
             res.write("{}");
             res.end();

--- a/packages/otel/src/instrumentations/fetch.ts
+++ b/packages/otel/src/instrumentations/fetch.ts
@@ -304,6 +304,11 @@ export class FetchInstrumentation implements Instrumentation {
 
       try {
         const startTime = Date.now();
+        // Remove "content-type" for a FormData body because undici regenerates
+        // a new multipart separator each time.
+        if (init?.body && init.body instanceof FormData) {
+          req.headers.delete("content-type");
+        }
         const res = await originalFetch(input, {
           ...init,
           headers: req.headers,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,7 +34,7 @@ importers:
         version: link:../../packages/bridge-emulator
       next:
         specifier: 14.2.1-canary.7
-        version: 14.2.1-canary.7(@opentelemetry/api@1.9.0)(react-dom@18.2.0)(react@18.2.0)
+        version: 14.2.1-canary.7(@opentelemetry/api@1.7.0)(react-dom@18.2.0)(react@18.2.0)
       react:
         specifier: ^18
         version: 18.2.0
@@ -127,10 +127,16 @@ importers:
       '@opentelemetry/api':
         specifier: ^1.7.0
         version: 1.7.0
+      formidable:
+        specifier: 3.5.2
+        version: 3.5.2
       next:
         specifier: 14.2.1-canary.7
         version: 14.2.1-canary.7(@opentelemetry/api@1.7.0)(react-dom@18.2.0)(react@18.2.0)
     devDependencies:
+      '@types/formidable':
+        specifier: 3.4.5
+        version: 3.4.5
       '@types/node':
         specifier: ^20
         version: 20.10.6
@@ -1555,16 +1561,6 @@ packages:
       '@opentelemetry/semantic-conventions': 1.24.1
     dev: true
 
-  /@opentelemetry/core@1.24.1(@opentelemetry/api@1.9.0):
-    resolution: {integrity: sha512-wMSGfsdmibI88K9wB498zXY04yThPexo8jvwNNlm542HZB7XrrMRBbAyKJqG8qDRJwIBdBrPMi4V9ZPW/sqrcg==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.0.0 <1.9.0'
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/semantic-conventions': 1.24.1
-    dev: false
-
   /@opentelemetry/exporter-trace-otlp-grpc@0.51.1(@opentelemetry/api@1.7.0):
     resolution: {integrity: sha512-P9+Hkszih95ITvldGZ+kXvj9HpD1QfS+PwooyHK72GYA+Bgm+yUSAsDkUkDms8+s9HW6poxURv3LcjaMuBBpVQ==}
     engines: {node: '>=14'}
@@ -1796,17 +1792,6 @@ packages:
       '@opentelemetry/semantic-conventions': 1.24.1
     dev: true
 
-  /@opentelemetry/resources@1.24.1(@opentelemetry/api@1.9.0):
-    resolution: {integrity: sha512-cyv0MwAaPF7O86x5hk3NNgenMObeejZFLJJDVuSeSMIsknlsj3oOZzRv3qSzlwYomXsICfBeFFlxwHQte5mGXQ==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.0.0 <1.9.0'
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 1.24.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.24.1
-    dev: false
-
   /@opentelemetry/sdk-logs@0.46.0(@opentelemetry/api-logs@0.46.0)(@opentelemetry/api@1.7.0):
     resolution: {integrity: sha512-Knlyk4+G72uEzNh6GRN1Fhmrj+/rkATI5/lOrevN7zRDLgp4kfyZBGGoWk7w+qQjlYvwhIIdPVxlIcipivdZIg==}
     engines: {node: '>=14'}
@@ -1902,18 +1887,6 @@ packages:
       '@opentelemetry/semantic-conventions': 1.24.1
     dev: true
 
-  /@opentelemetry/sdk-trace-base@1.24.1(@opentelemetry/api@1.9.0):
-    resolution: {integrity: sha512-zz+N423IcySgjihl2NfjBf0qw1RWe11XIAWVrTNOSSI6dtSPJiVom2zipFB2AEEtJWpv0Iz6DY6+TjnyTV5pWg==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.0.0 <1.9.0'
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 1.24.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 1.24.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.24.1
-    dev: false
-
   /@opentelemetry/sdk-trace-node@1.24.1(@opentelemetry/api@1.7.0):
     resolution: {integrity: sha512-/FZX8uWaGIAwsDhqI8VvQ+qWtfMNlXjaFYGc+vmxgdRFppCSSIRwrPyIhJO1qx61okyYhoyxVEZAfoiNxrfJCg==}
     engines: {node: '>=14'}
@@ -1936,6 +1909,7 @@ packages:
   /@opentelemetry/semantic-conventions@1.24.1:
     resolution: {integrity: sha512-VkliWlS4/+GHLLW7J/rVBA00uXus1SWvwFvcUDxDwmFxYfg/2VI6ekwdXS28cjI8Qz2ky2BzG8OUHo+WeYIWqw==}
     engines: {node: '>=14'}
+    dev: true
 
   /@pkgjs/parseargs@0.11.0:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -2156,6 +2130,12 @@ packages:
 
   /@types/estree@1.0.5:
     resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
+
+  /@types/formidable@3.4.5:
+    resolution: {integrity: sha512-s7YPsNVfnsng5L8sKnG/Gbb2tiwwJTY1conOkJzTMRvJAlLFW1nEua+ADsJQu8N1c0oTHx9+d5nqg10WuT9gHQ==}
+    dependencies:
+      '@types/node': 20.11.0
+    dev: true
 
   /@types/hast@2.3.9:
     resolution: {integrity: sha512-pTHyNlaMD/oKJmS+ZZUyFUcsZeBZpC0lmGquw98CqRVNgAdJZJeD7GoeLiT6Xbx5rU9VCjSt0RwEvDgzh4obFw==}
@@ -2791,6 +2771,10 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /asap@2.0.6:
+    resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
+    dev: false
+
   /assertion-error@1.1.0:
     resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
     dev: true
@@ -3262,6 +3246,13 @@ packages:
   /detect-newline@4.0.1:
     resolution: {integrity: sha512-qE3Veg1YXzGHQhlA6jzebZN2qVf6NX+A7m7qlhCGG30dJixrAQhYOsJjsnBjJkCSmuOPpCk30145fr8FV0bzog==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dev: false
+
+  /dezalgo@1.0.4:
+    resolution: {integrity: sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==}
+    dependencies:
+      asap: 2.0.6
+      wrappy: 1.0.2
     dev: false
 
   /didyoumean@1.2.2:
@@ -4408,6 +4399,14 @@ packages:
     engines: {node: '>=0.4.x'}
     dev: false
 
+  /formidable@3.5.2:
+    resolution: {integrity: sha512-Jqc1btCy3QzRbJaICGwKcBfGWuLADRerLzDqi2NwSt/UkXLsHJw2TVResiaoBufHVHy9aSgClOHCeJsSsFLTbg==}
+    dependencies:
+      dezalgo: 1.0.4
+      hexoid: 2.0.0
+      once: 1.4.0
+    dev: false
+
   /fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
     dev: true
@@ -4646,6 +4645,11 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       function-bind: 1.1.2
+
+  /hexoid@2.0.0:
+    resolution: {integrity: sha512-qlspKUK7IlSQv2o+5I7yhUd7TxlOG2Vr5LTa3ve2XSNVKAL/n/u/7KLvKmFNimomDIKvZFXWHv0T12mv7rT8Aw==}
+    engines: {node: '>=8'}
+    dev: false
 
   /hook-std@3.0.0:
     resolution: {integrity: sha512-jHRQzjSDzMtFy34AGj1DN+vq54WVuhSvKgrHf0OMiFQTwDD4L/qqofVEWjLOBMTn5+lCD3fPg32W9yOfnEJTTw==}
@@ -5870,49 +5874,6 @@ packages:
     dependencies:
       '@next/env': 14.2.1-canary.7
       '@opentelemetry/api': 1.7.0
-      '@swc/helpers': 0.5.5
-      busboy: 1.6.0
-      caniuse-lite: 1.0.30001579
-      graceful-fs: 4.2.11
-      postcss: 8.4.31
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      styled-jsx: 5.1.1(react@18.2.0)
-    optionalDependencies:
-      '@next/swc-darwin-arm64': 14.2.1-canary.7
-      '@next/swc-darwin-x64': 14.2.1-canary.7
-      '@next/swc-linux-arm64-gnu': 14.2.1-canary.7
-      '@next/swc-linux-arm64-musl': 14.2.1-canary.7
-      '@next/swc-linux-x64-gnu': 14.2.1-canary.7
-      '@next/swc-linux-x64-musl': 14.2.1-canary.7
-      '@next/swc-win32-arm64-msvc': 14.2.1-canary.7
-      '@next/swc-win32-ia32-msvc': 14.2.1-canary.7
-      '@next/swc-win32-x64-msvc': 14.2.1-canary.7
-    transitivePeerDependencies:
-      - '@babel/core'
-      - babel-plugin-macros
-    dev: false
-
-  /next@14.2.1-canary.7(@opentelemetry/api@1.9.0)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-XNK/yFbrMuY/mNXH0AaBU22osqv9teU5KxiCAT095g1nj/ruTE9fCh0C6bwKRZqc0EGT3HMsgFFgtaEcsZmjFA==}
-    engines: {node: '>=18.17.0'}
-    hasBin: true
-    peerDependencies:
-      '@opentelemetry/api': ^1.1.0
-      '@playwright/test': ^1.41.2
-      react: ^18.2.0
-      react-dom: ^18.2.0
-      sass: ^1.3.0
-    peerDependenciesMeta:
-      '@opentelemetry/api':
-        optional: true
-      '@playwright/test':
-        optional: true
-      sass:
-        optional: true
-    dependencies:
-      '@next/env': 14.2.1-canary.7
-      '@opentelemetry/api': 1.9.0
       '@swc/helpers': 0.5.5
       busboy: 1.6.0
       caniuse-lite: 1.0.30001579

--- a/tests/e2e/test/vercel-deployment/api-inbound.test.ts
+++ b/tests/e2e/test/vercel-deployment/api-inbound.test.ts
@@ -73,6 +73,75 @@ describe("vercel deployment: api inbound", {}, (props) => {
     });
   });
 
+  it("should trace api with FormData for serverless", async () => {
+    const { port, collector, bridge } = props();
+
+    const execResp = await bridge.fetch(
+      `/api/service/baz?dataUrl=${encodeURIComponent(
+        `http://localhost:${bridge.port}`
+      )}&mode=formdata`
+    );
+    expect(execResp.status).toBe(200);
+    expect(await execResp.text()).toEqual("Success baz bar");
+
+    await expectTrace(collector, {
+      name: "GET /api/service/[slug]/route",
+      status: { code: SpanStatusCode.UNSET },
+      kind: SpanKind.SERVER,
+      parentSpanId: undefined,
+      resource: {
+        "service.name": "sample-app",
+        "vercel.runtime": "nodejs",
+        env: "test",
+      },
+      attributes: {
+        scope: "next.js",
+        client: "bridge",
+        "vercel.request_id": "request1",
+        "next.span_name": "GET /api/service/[slug]/route",
+        "next.span_type": "BaseServer.handleRequest",
+        "http.method": "GET",
+        "http.host": `127.0.0.1:${port}`,
+        "http.status_code": 200,
+        "next.route": "/api/service/[slug]/route",
+        "http.route": "/api/service/[slug]/route",
+      },
+      spans: [
+        {
+          name: "executing api route (app) /api/service/[slug]/route",
+          kind: SpanKind.INTERNAL,
+          attributes: {
+            scope: "next.js",
+            "next.span_name":
+              "executing api route (app) /api/service/[slug]/route",
+            "next.span_type": "AppRouteRouteHandlers.runHandler",
+            "next.route": "/api/service/[slug]/route",
+          },
+          spans: [
+            {
+              name: "sample-span",
+              kind: SpanKind.INTERNAL,
+              attributes: { scope: "sample", foo: "bar" },
+              spans: [
+                {
+                  name: `fetch POST http://localhost:${bridge.port}/`,
+                  attributes: {
+                    scope: "@vercel/otel/fetch",
+                    "http.method": "POST",
+                    "http.url": `http://localhost:${bridge.port}/`,
+                    "net.peer.name": "localhost",
+                    "net.peer.port": `${bridge.port}`,
+                  },
+                  spans: [],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+  });
+
   it("should trace render for edge", async () => {
     const { collector, bridge } = props();
 


### PR DESCRIPTION
Undici regenerates multipart separator for each instantiation of Request and it does NOT overwrite the previous value. In order to avoid the problem, the content-type header must be cleared on a cloned request.