### PR TITLE
Release the `vercel-runtime` trace propagator and span processor

### DIFF
--- a/.changeset/tall-kids-warn.md
+++ b/.changeset/tall-kids-warn.md
@@ -1,0 +1,5 @@
+---
+"@vercel/otel": minor
+---
+
+Releases the `vercel-runtime` trace propagator and span processor

--- a/packages/bridge-emulator/src/server/index.ts
+++ b/packages/bridge-emulator/src/server/index.ts
@@ -1,6 +1,7 @@
 import type { Configuration } from "@vercel/otel";
 import type {
   Context,
+  SpanContext,
   TextMapGetter,
   TextMapPropagator,
   TextMapSetter,
@@ -12,6 +13,10 @@ export interface VercelRequestContext {
   ) => void;
   headers: Record<string, string | undefined>;
   url: string;
+  telemetry?: {
+    reportSpans: (data: unknown) => void;
+    rootSpanContext?: SpanContext;
+  };
   [key: symbol]: unknown;
 }
 
@@ -99,6 +104,12 @@ export class BridgeEmulatorContextReader implements TextMapPropagator {
                 console.error("[BridgeEmulatorServer] waitUntil error:", e);
               }
             });
+        },
+        telemetry: {
+          reportSpans: (data): void => {
+            // eslint-disable-next-line no-console
+            console.log("[BridgeEmulatorServer] reportSpans", data);
+          },
         },
       };
     }

--- a/packages/otel/src/sdk.ts
+++ b/packages/otel/src/sdk.ts
@@ -445,7 +445,6 @@ function parseSpanProcessor(
                 : new OTLPHttpJsonTraceExporter(config);
 
             processors.push(new BatchSpanProcessor(exporter));
-            // return new BatchSpanProcessor(exporter);
           }
 
           // Consider going throw `VERCEL_OTEL_ENDPOINTS` (otel collector) for OTLP.

--- a/packages/otel/src/sdk.ts
+++ b/packages/otel/src/sdk.ts
@@ -417,7 +417,7 @@ function parseSpanProcessor(
 ): SpanProcessor[] {
   return [
     ...(arg ?? ["auto"])
-      .map((spanProcessorOrName) => {
+      .flatMap((spanProcessorOrName) => {
         if (spanProcessorOrName === "auto") {
           const processors: SpanProcessor[] = [
             new BatchSpanProcessor(new VercelRuntimeSpanExporter()),
@@ -443,11 +443,13 @@ function parseSpanProcessor(
               protocol === "http/protobuf"
                 ? new OTLPHttpProtoTraceExporter(config)
                 : new OTLPHttpJsonTraceExporter(config);
+
             processors.push(new BatchSpanProcessor(exporter));
+            // return new BatchSpanProcessor(exporter);
           }
 
           // Consider going throw `VERCEL_OTEL_ENDPOINTS` (otel collector) for OTLP.
-          if (
+          else if (
             !configuration.traceExporter ||
             configuration.traceExporter === "auto" ||
             env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT ||
@@ -456,7 +458,7 @@ function parseSpanProcessor(
             return new BatchSpanProcessor(parseTraceExporter(env));
           }
 
-          return undefined;
+          return processors;
         }
         return spanProcessorOrName;
       })

--- a/packages/otel/src/types.ts
+++ b/packages/otel/src/types.ts
@@ -23,7 +23,6 @@ import type { FetchInstrumentationConfig } from "./instrumentations/fetch";
 export type PropagatorOrName =
   | TextMapPropagator
   | "auto"
-  | "experimental-vercel-trace"
   | "none"
   | "tracecontext"
   | "baggage";
@@ -38,7 +37,7 @@ export type SampleOrName =
   | "parentbased_traceidratio"
   | "traceidratio";
 
-export type SpanProcessorOrName = SpanProcessor | "auto" | "experimental-vercel-trace";
+export type SpanProcessorOrName = SpanProcessor | "auto";
 
 export type SpanExporterOrName = SpanExporter | "auto";
 


### PR DESCRIPTION
## What
- remove experimental options from types and update SDK to include new propagator and processors

## Example Config
With these latest changes, this is what your configuration should look like.

**Before** 
```ts
import { registerOTel } from '@vercel/otel'

export function register() {
  registerOTel({
    serviceName: '<your service name>',
    spanProcessors: ['auto', 'experimental-vercel-trace'],
    propagators: ['auto', 'experimental-vercel-trace'],
    ...
    // <other configuration from NodeSDK(...)> 
  })
}
```

**After**
```ts
import { registerOTel } from '@vercel/otel'

export function register() {
  registerOTel({
    serviceName: '<your service name>',
    ...
    // <other configuration from NodeSDK(...)> 
  })
}
```