### PR TITLE
feat(otel): add Vercel handler instrumentation for distributed tracing

### DIFF
--- a/packages/otel/src/instrumentations/vercel-handler.ts
+++ b/packages/otel/src/instrumentations/vercel-handler.ts
@@ -1,0 +1,63 @@
+import {
+  TracerProvider,
+  MeterProvider,
+  propagation,
+  context,
+} from "@opentelemetry/api";
+import type {
+  Instrumentation,
+  InstrumentationConfig,
+} from "@opentelemetry/instrumentation";
+import { Server } from "node:http";
+
+export interface VercelHandlerInstrumentationConfig
+  extends InstrumentationConfig {}
+
+export class VercelHandlerInstrumentation implements Instrumentation {
+  instrumentationName = "@vercel/otel/handlers";
+  instrumentationVersion = "1.0.0";
+  instrumentationDescription?: string;
+
+  traceProvider?: TracerProvider;
+  supportedVersions?: string[];
+
+  enabled = false;
+
+  constructor(readonly config: VercelHandlerInstrumentationConfig) {
+    patchEmit(() => this.enabled);
+    this.enabled = config.enabled ?? false;
+  }
+  disable(): void {
+    this.enabled = false;
+  }
+  enable(): void {
+    this.enabled = true;
+  }
+  setTracerProvider(tracerProvider: TracerProvider): void {
+    this.traceProvider = tracerProvider;
+  }
+  setMeterProvider(_meterProvider: MeterProvider): void {
+    // nothing
+  }
+  setConfig(_config: InstrumentationConfig): void {
+    // nothing
+  }
+  getConfig(): InstrumentationConfig {
+    return this.config;
+  }
+}
+
+function patchEmit(isEnabled: () => boolean) {
+  const emit = Server.prototype.emit;
+  Server.prototype.emit = function (event: any, ...args: any[]) {
+    const next = () => emit.call(this, event, ...args);
+    if (isEnabled() && event === "request") {
+      const request = args[0];
+      console.log("instrumenting request", request.headers);
+      const c = propagation.extract(context.active(), request.headers);
+      return context.with(c, next);
+    }
+
+    return next();
+  };
+}


### PR DESCRIPTION
Implements OpenTelemetry instrumentation for Vercel handlers by patching
the Node.js HTTP Server's emit method to automatically extract trace
context from incoming request headers and propagate it through the
request lifecycle.

🤖 Generated with [opencode](https://opencode.ai)
