### PR TITLE
[chore] fix: v1 is not a valid tag

### DIFF
--- a/.github/workflows/release-v1.yml
+++ b/.github/workflows/release-v1.yml
@@ -40,4 +40,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN_ELEVATED }}
-          TAG: v1
+          TAG: otel-sdk-1


### PR DESCRIPTION
change tag to `otel-sdk-1`

https://github.com/vercel/otel/actions/runs/18159609818/job/51687215502