### PR TITLE
fix: don't inline system env vars

### DIFF
--- a/.changeset/spicy-dingos-speak.md
+++ b/.changeset/spicy-dingos-speak.md
@@ -1,0 +1,5 @@
+---
+"@vercel/otel": patch
+---
+
+fix: don't inline system env vars

--- a/packages/otel/src/instrumentations/fetch.ts
+++ b/packages/otel/src/instrumentations/fetch.ts
@@ -169,12 +169,8 @@ export class FetchInstrumentation implements Instrumentation {
   }
 
   private shouldPropagate(url: URL, init?: InternalRequestInit): boolean {
-    const host =
-      process.env.VERCEL_URL || process.env.NEXT_PUBLIC_VERCEL_URL || null;
-    const branchHost =
-      process.env.VERCEL_BRANCH_URL ||
-      process.env.NEXT_PUBLIC_VERCEL_BRANCH_URL ||
-      null;
+    const host = process.env.VERCEL_URL || null;
+    const branchHost = process.env.VERCEL_BRANCH_URL || null;
     const propagateContextUrls = this.config.propagateContextUrls ?? [];
     const dontPropagateContextUrls = this.config.dontPropagateContextUrls ?? [];
     if (init?.opentelemetry?.propagateContext) {

--- a/packages/otel/src/sdk.ts
+++ b/packages/otel/src/sdk.ts
@@ -128,20 +128,12 @@ export class Sdk {
         // Vercel.
         // https://vercel.com/docs/projects/environment-variables/system-environment-variables
         // Vercel Env set as top level attribute for simplicity. One of 'production', 'preview' or 'development'.
-        env: process.env.VERCEL_ENV || process.env.NEXT_PUBLIC_VERCEL_ENV,
+        env: process.env.VERCEL_ENV,
         "vercel.region": process.env.VERCEL_REGION,
         "vercel.runtime": runtime,
-        "vercel.sha":
-          process.env.VERCEL_GIT_COMMIT_SHA ||
-          process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA,
-        "vercel.host":
-          process.env.VERCEL_URL ||
-          process.env.NEXT_PUBLIC_VERCEL_URL ||
-          undefined,
-        "vercel.branch_host":
-          process.env.VERCEL_BRANCH_URL ||
-          process.env.NEXT_PUBLIC_VERCEL_BRANCH_URL ||
-          undefined,
+        "vercel.sha": process.env.VERCEL_GIT_COMMIT_SHA,
+        "vercel.host": process.env.VERCEL_URL || undefined,
+        "vercel.branch_host": process.env.VERCEL_BRANCH_URL || undefined,
         "vercel.deployment_id": process.env.VERCEL_DEPLOYMENT_ID || undefined,
         [SemanticResourceAttributes.SERVICE_VERSION]:
           process.env.VERCEL_DEPLOYMENT_ID,


### PR DESCRIPTION
My understanding is that all of this code runs only server-side
In that case, there is no benefit to trying to fallback to `NEXT_PUBLIC_VERCEL_URL` (the only case where it's necessary is for client-side code, where there is obviously no `process.env` at runtime.)

This means that the JS chunks in the serverless function are now deterministic as `NEXT_PUBLIC_` always inlined the value into the JS chunk
