### PR TITLE
fix(otel): add VCS resource attributes

### DIFF
--- a/.changeset/0000-resource-attrs.md
+++ b/.changeset/0000-resource-attrs.md
@@ -1,0 +1,5 @@
+---
+"@vercel/otel": patch
+---
+
+Add standard OpenTelemetry resource attributes for VCS.

--- a/packages/otel/README.md
+++ b/packages/otel/README.md
@@ -47,7 +47,7 @@ Registers the OpenTelemetry SDK with the specified service name and the default 
 Registers the OpenTelemetry SDK with the specified configuration. Configuration options include:
 
 - `serviceName`: The name of your service, used as the app name in many OpenTelemetry backends.
-- `attributes`: The resource attributes. By default, `@vercel/otel` configures standard OpenTelemetry resource attributes such as `deployment.environment.name`, `cloud.region`, `process.runtime.name`, `vcs.ref.head.name`, `vcs.ref.head.revision`, `vcs.ref.type`, `vcs.repository.name`, and `deployment.id`, while keeping compatibility attributes such as `env`, `vercel.*`, `service.version`, and `vcs.repository.ref.revision`.
+- `attributes`: The resource attributes. By default, `@vercel/otel` configures standard OpenTelemetry resource attributes such as `deployment.environment.name`, `cloud.region`, `process.runtime.name`, `vcs.ref.head.name`, `vcs.ref.head.revision`, `vcs.repository.name`, and `deployment.id`, while keeping compatibility attributes such as `env`, `vercel.*`, `service.version`, and `vcs.repository.ref.revision`.
 - `instrumentations`: A set of instrumentations. By default, `@vercel/otel` configures "fetch" instrumentation.
 - `instrumentationConfig`: Customize configuration for predefined instrumentations:
   - `fetch`: Customize configuration of the predefined "fetch" instrumentation:

--- a/packages/otel/README.md
+++ b/packages/otel/README.md
@@ -47,7 +47,7 @@ Registers the OpenTelemetry SDK with the specified service name and the default 
 Registers the OpenTelemetry SDK with the specified configuration. Configuration options include:
 
 - `serviceName`: The name of your service, used as the app name in many OpenTelemetry backends.
-- `attributes`: The resource attributes. By default, `@vercel/otel` configures relevant Vercel attributes based on [the environment](https://vercel.com/docs/projects/environment-variables/system-environment-variables), such as `env`, `vercel.runtime`, `vercel.host`, etc.
+- `attributes`: The resource attributes. By default, `@vercel/otel` configures standard OpenTelemetry resource attributes such as `deployment.environment.name`, `cloud.region`, `process.runtime.name`, `vcs.ref.head.name`, `vcs.ref.head.revision`, `vcs.ref.type`, `vcs.repository.name`, and `deployment.id`, while keeping compatibility attributes such as `env`, `vercel.*`, `service.version`, and `vcs.repository.ref.revision`.
 - `instrumentations`: A set of instrumentations. By default, `@vercel/otel` configures "fetch" instrumentation.
 - `instrumentationConfig`: Customize configuration for predefined instrumentations:
   - `fetch`: Customize configuration of the predefined "fetch" instrumentation:

--- a/packages/otel/src/sdk.ts
+++ b/packages/otel/src/sdk.ts
@@ -39,11 +39,10 @@ import {
   W3CBaggagePropagator,
   parseKeyPairsIntoRecord,
 } from "@opentelemetry/core";
-import * as SemanticResourceAttributes from "./semantic-resource-attributes";
 import { CompositeSpanProcessor } from "./processor/composite-span-processor";
 import { OTLPHttpJsonTraceExporter } from "./exporters/exporter-trace-otlp-http-fetch";
 import { OTLPHttpProtoTraceExporter } from "./exporters/exporter-trace-otlp-proto-fetch";
-import { omitUndefinedAttributes } from "./util/attributes";
+import { getDefaultResourceAttributes } from "./util/attributes";
 import type {
   Configuration,
   InstrumentationConfiguration,
@@ -118,28 +117,10 @@ export class Sdk {
     const serviceName =
       env.OTEL_SERVICE_NAME || configuration.serviceName || "app";
     let resource = resourceFromAttributes(
-      omitUndefinedAttributes({
-        [SemanticResourceAttributes.SERVICE_NAME]: serviceName,
-
-        // Node.
-        "node.ci": process.env.CI ? true : undefined,
-        "node.env": process.env.NODE_ENV,
-
-        // Vercel.
-        // https://vercel.com/docs/projects/environment-variables/system-environment-variables
-        // Vercel Env set as top level attribute for simplicity. One of 'production', 'preview' or 'development'.
-        env: process.env.VERCEL_ENV,
-        "vercel.region": process.env.VERCEL_REGION,
-        "vercel.runtime": runtime,
-        "vercel.sha": process.env.VERCEL_GIT_COMMIT_SHA,
-        "vercel.host": process.env.VERCEL_URL || undefined,
-        "vercel.branch_host": process.env.VERCEL_BRANCH_URL || undefined,
-        "vercel.deployment_id": process.env.VERCEL_DEPLOYMENT_ID || undefined,
-        [SemanticResourceAttributes.SERVICE_VERSION]:
-          process.env.VERCEL_DEPLOYMENT_ID,
-        "vercel.project_id": process.env.VERCEL_PROJECT_ID || undefined,
-
-        ...configuration.attributes,
+      getDefaultResourceAttributes({
+        attributes: configuration.attributes,
+        runtime,
+        serviceName,
       }),
     );
     const resourceDetectors = configuration.resourceDetectors ?? [envDetector];

--- a/packages/otel/src/semantic-resource-attributes.ts
+++ b/packages/otel/src/semantic-resource-attributes.ts
@@ -9,10 +9,19 @@ export const HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED =
 export const NET_PEER_PORT = "net.peer.port";
 export const NET_PEER_NAME = "net.peer.name";
 export const CLOUD_REGION = "cloud.region";
+/** @deprecated Use DEPLOYMENT_ENVIRONMENT_NAME instead. */
 export const DEPLOYMENT_ENVIRONMENT = "deployment.environment";
+export const DEPLOYMENT_ENVIRONMENT_NAME = "deployment.environment.name";
+export const DEPLOYMENT_ID = "deployment.id";
 export const CLOUD_PROVIDER = "cloud.provider";
 export const PROCESS_RUNTIME_NAME = "process.runtime.name";
-export const VCS_REPOSITORY_REF_VERSION = "vcs.repository.ref.revision";
+export const VCS_REF_HEAD_NAME = "vcs.ref.head.name";
+export const VCS_REF_HEAD_REVISION = "vcs.ref.head.revision";
+export const VCS_REF_TYPE = "vcs.ref.type";
+export const VCS_REPOSITORY_NAME = "vcs.repository.name";
+export const VCS_REPOSITORY_REF_REVISION = "vcs.repository.ref.revision";
+/** @deprecated Use VCS_REPOSITORY_REF_REVISION instead. */
+export const VCS_REPOSITORY_REF_VERSION = VCS_REPOSITORY_REF_REVISION;
 export const FAAS_INVOKED_REGION = "faas.invoked_region";
 export const FAAS_INVOCATION_ID = "faas.invocation_id";
 export const SERVICE_NAME = "service.name";

--- a/packages/otel/src/semantic-resource-attributes.ts
+++ b/packages/otel/src/semantic-resource-attributes.ts
@@ -17,7 +17,6 @@ export const CLOUD_PROVIDER = "cloud.provider";
 export const PROCESS_RUNTIME_NAME = "process.runtime.name";
 export const VCS_REF_HEAD_NAME = "vcs.ref.head.name";
 export const VCS_REF_HEAD_REVISION = "vcs.ref.head.revision";
-export const VCS_REF_TYPE = "vcs.ref.type";
 export const VCS_REPOSITORY_NAME = "vcs.repository.name";
 export const VCS_REPOSITORY_REF_REVISION = "vcs.repository.ref.revision";
 /** @deprecated Use VCS_REPOSITORY_REF_REVISION instead. */

--- a/packages/otel/src/types.ts
+++ b/packages/otel/src/types.ts
@@ -61,6 +61,16 @@ export interface Configuration {
    * including:
    * - `service.name` - the service name.
    * - `node.env` - the value of `NODE_ENV` environment variable.
+   * - `deployment.environment.name` - the Vercel deployment environment.
+   * - `cloud.region` - the Vercel deployment region.
+   * - `process.runtime.name` - the runtime when the SDK can determine it, such as "nodejs" or "edge".
+   * - `vcs.ref.head.name` - the Vercel Git ref when available.
+   * - `vcs.ref.head.revision` - the Vercel Git SHA.
+   * - `vcs.ref.type` - `branch` when the Vercel Git ref is available.
+   * - `vcs.repository.name` - the Vercel repository slug when available.
+   * - `deployment.id` - the Vercel deployment ID.
+   * - `service.version` - the Vercel deployment ID.
+   * - legacy compatibility aliases such as `env` and `vercel.*`.
    * - `env` - the Vercel deployment environment such as "production" or "preview" (`VERCEL_ENV` environment variable).
    * - `vercel.region` - the Vercel deployment region (`VERCEL_REGION` environment variable).
    * - `vercel.runtime` - "nodejs" or "edge" (`NEXT_RUNTIME` environment variable).

--- a/packages/otel/src/types.ts
+++ b/packages/otel/src/types.ts
@@ -66,7 +66,6 @@ export interface Configuration {
    * - `process.runtime.name` - the runtime when the SDK can determine it, such as "nodejs" or "edge".
    * - `vcs.ref.head.name` - the Vercel Git ref when available.
    * - `vcs.ref.head.revision` - the Vercel Git SHA.
-   * - `vcs.ref.type` - `branch` when the Vercel Git ref is available.
    * - `vcs.repository.name` - the Vercel repository slug when available.
    * - `deployment.id` - the Vercel deployment ID.
    * - `service.version` - the Vercel deployment ID.

--- a/packages/otel/src/util/attributes.test.ts
+++ b/packages/otel/src/util/attributes.test.ts
@@ -61,18 +61,6 @@ describe("getDefaultResourceAttributes", () => {
     });
   });
 
-  it("should omit runtime attributes when runtime is unknown", () => {
-    const attributes = getDefaultResourceAttributes({
-      env: {
-        VERCEL_ENV: "preview",
-      },
-      serviceName: "app",
-    });
-
-    expect(attributes[PROCESS_RUNTIME_NAME]).toBeUndefined();
-    expect(attributes["vercel.runtime"]).toBeUndefined();
-  });
-
   it("should merge user attributes last", () => {
     const attributes = getDefaultResourceAttributes({
       attributes: {

--- a/packages/otel/src/util/attributes.test.ts
+++ b/packages/otel/src/util/attributes.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import {
+  CLOUD_REGION,
+  DEPLOYMENT_ENVIRONMENT_NAME,
+  DEPLOYMENT_ID,
+  PROCESS_RUNTIME_NAME,
+  SERVICE_NAME,
+  SERVICE_VERSION,
+  VCS_REF_HEAD_NAME,
+  VCS_REF_HEAD_REVISION,
+  VCS_REF_TYPE,
+  VCS_REPOSITORY_NAME,
+  VCS_REPOSITORY_REF_REVISION,
+} from "../semantic-resource-attributes";
+import { getDefaultResourceAttributes } from "./attributes";
+
+describe("getDefaultResourceAttributes", () => {
+  it("should emit standard and legacy Vercel resource attributes", () => {
+    const attributes = getDefaultResourceAttributes({
+      env: {
+        CI: "1",
+        NODE_ENV: "production",
+        VERCEL_BRANCH_URL: "feature-branch.vercel.app",
+        VERCEL_DEPLOYMENT_ID: "dpl_123",
+        VERCEL_ENV: "preview",
+        VERCEL_GIT_COMMIT_REF: "feature/refactor",
+        VERCEL_GIT_COMMIT_SHA: "abc123",
+        VERCEL_GIT_PROVIDER: "github",
+        VERCEL_GIT_REPO_OWNER: "vercel",
+        VERCEL_GIT_REPO_SLUG: "otel",
+        VERCEL_PROJECT_ID: "prj_123",
+        VERCEL_REGION: "fra1",
+        VERCEL_URL: "deployment.vercel.app",
+      },
+      runtime: "nodejs",
+      serviceName: "app",
+    });
+
+    expect(attributes).toEqual({
+      [CLOUD_REGION]: "fra1",
+      [DEPLOYMENT_ENVIRONMENT_NAME]: "preview",
+      [DEPLOYMENT_ID]: "dpl_123",
+      [PROCESS_RUNTIME_NAME]: "nodejs",
+      [SERVICE_NAME]: "app",
+      [SERVICE_VERSION]: "dpl_123",
+      [VCS_REF_HEAD_NAME]: "feature/refactor",
+      [VCS_REF_HEAD_REVISION]: "abc123",
+      [VCS_REF_TYPE]: "branch",
+      [VCS_REPOSITORY_NAME]: "otel",
+      [VCS_REPOSITORY_REF_REVISION]: "abc123",
+      env: "preview",
+      "node.ci": true,
+      "node.env": "production",
+      "vercel.branch_host": "feature-branch.vercel.app",
+      "vercel.deployment_id": "dpl_123",
+      "vercel.host": "deployment.vercel.app",
+      "vercel.project_id": "prj_123",
+      "vercel.region": "fra1",
+      "vercel.runtime": "nodejs",
+      "vercel.sha": "abc123",
+    });
+  });
+
+  it("should omit runtime attributes when runtime is unknown", () => {
+    const attributes = getDefaultResourceAttributes({
+      env: {
+        VERCEL_ENV: "preview",
+      },
+      serviceName: "app",
+    });
+
+    expect(attributes[PROCESS_RUNTIME_NAME]).toBeUndefined();
+    expect(attributes["vercel.runtime"]).toBeUndefined();
+  });
+
+  it("should merge user attributes last", () => {
+    const attributes = getDefaultResourceAttributes({
+      attributes: {
+        [DEPLOYMENT_ID]: "custom-deploy",
+        [DEPLOYMENT_ENVIRONMENT_NAME]: "custom-env",
+      },
+      env: {
+        VERCEL_DEPLOYMENT_ID: "dpl_123",
+        VERCEL_ENV: "preview",
+      },
+      runtime: "nodejs",
+      serviceName: "app",
+    });
+
+    expect(attributes[DEPLOYMENT_ID]).toBe("custom-deploy");
+    expect(attributes[DEPLOYMENT_ENVIRONMENT_NAME]).toBe("custom-env");
+    expect(attributes["vercel.deployment_id"]).toBe("dpl_123");
+    expect(attributes.env).toBe("preview");
+  });
+});

--- a/packages/otel/src/util/attributes.test.ts
+++ b/packages/otel/src/util/attributes.test.ts
@@ -8,7 +8,6 @@ import {
   SERVICE_VERSION,
   VCS_REF_HEAD_NAME,
   VCS_REF_HEAD_REVISION,
-  VCS_REF_TYPE,
   VCS_REPOSITORY_NAME,
   VCS_REPOSITORY_REF_REVISION,
 } from "../semantic-resource-attributes";
@@ -45,7 +44,6 @@ describe("getDefaultResourceAttributes", () => {
       [SERVICE_VERSION]: "dpl_123",
       [VCS_REF_HEAD_NAME]: "feature/refactor",
       [VCS_REF_HEAD_REVISION]: "abc123",
-      [VCS_REF_TYPE]: "branch",
       [VCS_REPOSITORY_NAME]: "otel",
       [VCS_REPOSITORY_REF_REVISION]: "abc123",
       env: "preview",

--- a/packages/otel/src/util/attributes.ts
+++ b/packages/otel/src/util/attributes.ts
@@ -1,4 +1,17 @@
 import type { Attributes } from "@opentelemetry/api";
+import {
+  CLOUD_REGION,
+  DEPLOYMENT_ENVIRONMENT_NAME,
+  DEPLOYMENT_ID,
+  PROCESS_RUNTIME_NAME,
+  SERVICE_NAME,
+  SERVICE_VERSION,
+  VCS_REF_HEAD_NAME,
+  VCS_REF_HEAD_REVISION,
+  VCS_REF_TYPE,
+  VCS_REPOSITORY_NAME,
+  VCS_REPOSITORY_REF_REVISION,
+} from "../semantic-resource-attributes";
 
 /** @internal */
 export function omitUndefinedAttributes<T extends Attributes = Attributes>(
@@ -7,4 +20,48 @@ export function omitUndefinedAttributes<T extends Attributes = Attributes>(
   return Object.fromEntries(
     Object.entries(obj).filter(([_, value]) => value !== undefined),
   ) as T;
+}
+
+export function getDefaultResourceAttributes({
+  attributes,
+  env = process.env,
+  runtime,
+  serviceName,
+}: {
+  attributes?: Attributes;
+  env?: NodeJS.ProcessEnv;
+  runtime: string;
+  serviceName: string;
+}): Attributes {
+  const deploymentEnvironment = env.VERCEL_ENV;
+  const deploymentId = env.VERCEL_DEPLOYMENT_ID;
+  const gitRevision = env.VERCEL_GIT_COMMIT_SHA;
+  const region = env.VERCEL_REGION;
+  const gitRef = env.VERCEL_GIT_COMMIT_REF;
+  const repositoryName = env.VERCEL_GIT_REPO_SLUG;
+
+  return omitUndefinedAttributes({
+    [SERVICE_NAME]: serviceName,
+    "node.ci": env.CI ? true : undefined,
+    "node.env": env.NODE_ENV,
+    [DEPLOYMENT_ENVIRONMENT_NAME]: deploymentEnvironment,
+    env: deploymentEnvironment,
+    [CLOUD_REGION]: region,
+    "vercel.region": region,
+    [PROCESS_RUNTIME_NAME]: runtime,
+    "vercel.runtime": runtime,
+    [VCS_REF_HEAD_NAME]: gitRef,
+    [VCS_REF_HEAD_REVISION]: gitRevision,
+    [VCS_REF_TYPE]: gitRef ? "branch" : undefined,
+    [VCS_REPOSITORY_NAME]: repositoryName,
+    [VCS_REPOSITORY_REF_REVISION]: gitRevision,
+    "vercel.sha": gitRevision,
+    "vercel.host": env.VERCEL_URL || undefined,
+    "vercel.branch_host": env.VERCEL_BRANCH_URL || undefined,
+    [DEPLOYMENT_ID]: deploymentId,
+    "vercel.deployment_id": deploymentId,
+    [SERVICE_VERSION]: deploymentId,
+    "vercel.project_id": env.VERCEL_PROJECT_ID || undefined,
+    ...attributes,
+  });
 }

--- a/packages/otel/src/util/attributes.ts
+++ b/packages/otel/src/util/attributes.ts
@@ -8,7 +8,6 @@ import {
   SERVICE_VERSION,
   VCS_REF_HEAD_NAME,
   VCS_REF_HEAD_REVISION,
-  VCS_REF_TYPE,
   VCS_REPOSITORY_NAME,
   VCS_REPOSITORY_REF_REVISION,
 } from "../semantic-resource-attributes";
@@ -52,7 +51,6 @@ export function getDefaultResourceAttributes({
     "vercel.runtime": runtime,
     [VCS_REF_HEAD_NAME]: gitRef,
     [VCS_REF_HEAD_REVISION]: gitRevision,
-    [VCS_REF_TYPE]: gitRef ? "branch" : undefined,
     [VCS_REPOSITORY_NAME]: repositoryName,
     [VCS_REPOSITORY_REF_REVISION]: gitRevision,
     "vercel.sha": gitRevision,


### PR DESCRIPTION
## Problem
- Default resource attributes were missing VCS metadata described in the OpenTelemetry semantic conventions [here](https://opentelemetry.io/docs/specs/semconv/registry/entities/vcs/)

## Solution
- add the missing VCS resource attributes from the OpenTelemetry semantic conventions
- keep existing resource attributes for compatibility
- move attribute helper utilities to `src/util/attributes.ts`
- keep semantic attribute constants in `src/semantic-resource-attributes.ts`
- mark `DEPLOYMENT_ENVIRONMENT` & `VCS_REPOSITORY_REF_VERSION` as deprecated
- add tests
