### PR TITLE
feat(otel): add semantic cloud resource attributes

### DIFF
--- a/.changeset/ten-pumpkins-fix.md
+++ b/.changeset/ten-pumpkins-fix.md
@@ -1,0 +1,6 @@
+---
+"@vercel/otel": patch
+---
+
+Add OpenTelemetry semantic convention resource attributes for Vercel defaults. `cloud.provider` is now set to `vercel`, and `cloud.region` continues to be emitted from `VERCEL_REGION`.
+

--- a/packages/otel/README.md
+++ b/packages/otel/README.md
@@ -47,7 +47,7 @@ Registers the OpenTelemetry SDK with the specified service name and the default 
 Registers the OpenTelemetry SDK with the specified configuration. Configuration options include:
 
 - `serviceName`: The name of your service, used as the app name in many OpenTelemetry backends.
-- `attributes`: The resource attributes. By default, `@vercel/otel` configures standard OpenTelemetry resource attributes such as `deployment.environment.name`, `cloud.region`, `process.runtime.name`, `vcs.ref.head.name`, `vcs.ref.head.revision`, `vcs.repository.name`, and `deployment.id`, while keeping compatibility attributes such as `env`, `vercel.*`, `service.version`, and `vcs.repository.ref.revision`.
+- `attributes`: The resource attributes. By default, `@vercel/otel` configures standard OpenTelemetry resource attributes such as `deployment.environment.name`, `cloud.provider`, `cloud.region`, `process.runtime.name`, `vcs.ref.head.name`, `vcs.ref.head.revision`, `vcs.repository.name`, and `deployment.id`, while keeping compatibility attributes such as `env`, `vercel.*`, `service.version`, and `vcs.repository.ref.revision`.
 - `instrumentations`: A set of instrumentations. By default, `@vercel/otel` configures "fetch" instrumentation.
 - `instrumentationConfig`: Customize configuration for predefined instrumentations:
   - `fetch`: Customize configuration of the predefined "fetch" instrumentation:

--- a/packages/otel/src/types.ts
+++ b/packages/otel/src/types.ts
@@ -62,6 +62,7 @@ export interface Configuration {
    * - `service.name` - the service name.
    * - `node.env` - the value of `NODE_ENV` environment variable.
    * - `deployment.environment.name` - the Vercel deployment environment.
+   * - `cloud.provider` - "vercel".
    * - `cloud.region` - the Vercel deployment region.
    * - `process.runtime.name` - the runtime when the SDK can determine it, such as "nodejs" or "edge".
    * - `vcs.ref.head.name` - the Vercel Git ref when available.

--- a/packages/otel/src/util/attributes.test.ts
+++ b/packages/otel/src/util/attributes.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  CLOUD_PROVIDER,
   CLOUD_REGION,
   DEPLOYMENT_ENVIRONMENT_NAME,
   DEPLOYMENT_ID,
@@ -36,6 +37,7 @@ describe("getDefaultResourceAttributes", () => {
     });
 
     expect(attributes).toEqual({
+      [CLOUD_PROVIDER]: "vercel",
       [CLOUD_REGION]: "fra1",
       [DEPLOYMENT_ENVIRONMENT_NAME]: "preview",
       [DEPLOYMENT_ID]: "dpl_123",

--- a/packages/otel/src/util/attributes.ts
+++ b/packages/otel/src/util/attributes.ts
@@ -1,5 +1,6 @@
 import type { Attributes } from "@opentelemetry/api";
 import {
+  CLOUD_PROVIDER,
   CLOUD_REGION,
   DEPLOYMENT_ENVIRONMENT_NAME,
   DEPLOYMENT_ID,
@@ -45,6 +46,7 @@ export function getDefaultResourceAttributes({
     "node.env": env.NODE_ENV,
     [DEPLOYMENT_ENVIRONMENT_NAME]: deploymentEnvironment,
     env: deploymentEnvironment,
+    [CLOUD_PROVIDER]: "vercel",
     [CLOUD_REGION]: region,
     "vercel.region": region,
     [PROCESS_RUNTIME_NAME]: runtime,


### PR DESCRIPTION
Adds `cloud.provider` to default `@vercel/otel` resource attributes. This improves interoperability with OpenTelemetry semantic conventions and observability UIs.

Refs: https://github.com/vercel/otel/issues/103