### PR TITLE
ci(release): pin changesets action for signed releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,10 +34,12 @@ jobs:
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets
-        uses: changesets/action@v1
+        # uses: changesets/action@v1
+        uses: changesets/action@d4c53c294341eec8a419ec2d1927138bfdeec234
         with:
           publish: pnpm release
           version: pnpm version-packages
+          commitMode: "github-api" # allows release commits and tags to be signed using $GITHUB_TOKEN
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN_ELEVATED }}


### PR DESCRIPTION
Updated changesets action version and added commit mode for signed releases.

See PR here https://github.com/changesets/action/pull/391