### PR TITLE
chore: use Node 24 for release actions

### DIFF
--- a/.node-version
+++ b/.node-version
@@ -1,1 +1,1 @@
-lts/hydrogen
+24


### PR DESCRIPTION
## Problem
- Release workflow uses Node 18, which fails loading ESM-only Changesets deps.

## Solution
- Set repo Node version to 24 for release workflows.
- Keep non-release CI on Node 18 to preserve consumer support coverage.