### PR TITLE
[@vercel/otel] Prevent local span export if already emitted via drains

### DIFF
--- a/.changeset/0000-avoid-local-otlp.md
+++ b/.changeset/0000-avoid-local-otlp.md
@@ -1,0 +1,5 @@
+---
+"@vercel/otel": patch
+---
+
+Avoid local OTLP exports for drained Vercel traces when request context is lost before span end.

--- a/packages/otel/src/processor/filter-when-drained-span-processor.test.ts
+++ b/packages/otel/src/processor/filter-when-drained-span-processor.test.ts
@@ -1,0 +1,150 @@
+import { context, TraceFlags, type SpanContext } from "@opentelemetry/api";
+import type {
+  ReadableSpan,
+  Span,
+  SpanProcessor,
+} from "@opentelemetry/sdk-trace-base";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { VercelRequestContext } from "../vercel-request-context/api";
+import { FilterWhenDrainedSpanProcessor } from "./filter-when-drained-span-processor";
+
+const requestContextSymbol = Symbol.for("@vercel/request-context");
+
+let activeContext: VercelRequestContext | undefined;
+
+beforeEach(() => {
+  activeContext = undefined;
+  Reflect.set(globalThis, requestContextSymbol, {
+    get: () => activeContext,
+  });
+});
+
+afterEach(() => {
+  Reflect.deleteProperty(globalThis, requestContextSymbol);
+});
+
+describe("FilterWhenDrainedSpanProcessor", () => {
+  it("forwards spans when there are no trace drains", () => {
+    const { onEnd, onStart, processor } = createProcessor();
+    const filter = new FilterWhenDrainedSpanProcessor(processor);
+    const span = createSpan();
+
+    filter.onStart(span, context.active());
+    filter.onEnd(span);
+
+    expect(onStart).toHaveBeenCalledWith(span, context.active());
+    expect(onEnd).toHaveBeenCalledWith(span);
+  });
+
+  it("skips spans when trace drains are configured", () => {
+    activeContext = createDrainingContext();
+    const { onEnd, onStart, processor } = createProcessor();
+    const filter = new FilterWhenDrainedSpanProcessor(processor);
+    const span = createSpan();
+
+    filter.onStart(span, context.active());
+    filter.onEnd(span);
+
+    expect(onStart).not.toHaveBeenCalled();
+    expect(onEnd).not.toHaveBeenCalled();
+  });
+
+  it("skips drained spans when request context is lost before span end", () => {
+    activeContext = createDrainingContext();
+    const { onEnd, onStart, processor } = createProcessor();
+    const filter = new FilterWhenDrainedSpanProcessor(processor);
+    const span = createSpan();
+
+    filter.onStart(span, context.active());
+    activeContext = undefined;
+    filter.onEnd(span);
+
+    expect(onStart).not.toHaveBeenCalled();
+    expect(onEnd).not.toHaveBeenCalled();
+  });
+
+  it("does not skip unrelated spans after request context is lost", () => {
+    activeContext = createDrainingContext();
+    const { onEnd, onStart, processor } = createProcessor();
+    const filter = new FilterWhenDrainedSpanProcessor(processor);
+    const drainedSpan = createSpan("0".repeat(32), "0".repeat(16));
+    const otherSpan = createSpan("1".repeat(32), "1".repeat(16));
+
+    filter.onStart(drainedSpan, context.active());
+    activeContext = undefined;
+    filter.onEnd(otherSpan);
+
+    expect(onStart).not.toHaveBeenCalled();
+    expect(onEnd).toHaveBeenCalledWith(otherSpan);
+  });
+
+  it("caps remembered drained spans", () => {
+    activeContext = createDrainingContext();
+    const { onEnd, processor } = createProcessor();
+    const filter = new FilterWhenDrainedSpanProcessor(processor);
+    const firstSpan = createSpan("0".repeat(32), "0".repeat(16));
+
+    filter.onStart(firstSpan, context.active());
+    for (let i = 1; i <= 10_000; i++) {
+      filter.onStart(createSpan(createTraceId(i), createSpanId(i)), context.active());
+    }
+
+    activeContext = undefined;
+    filter.onEnd(firstSpan);
+    filter.onEnd(createSpan(createTraceId(10_000), createSpanId(10_000)));
+
+    expect(onEnd).toHaveBeenCalledTimes(1);
+    expect(onEnd).toHaveBeenCalledWith(firstSpan);
+  });
+});
+
+function createProcessor(): {
+  onEnd: ReturnType<typeof vi.fn>;
+  onStart: ReturnType<typeof vi.fn>;
+  processor: SpanProcessor;
+} {
+  const onEnd = vi.fn();
+  const onStart = vi.fn();
+  return {
+    onEnd,
+    onStart,
+    processor: {
+      forceFlush: vi.fn(() => Promise.resolve()),
+      onEnd,
+      onStart,
+      shutdown: vi.fn(() => Promise.resolve()),
+    },
+  };
+}
+
+function createDrainingContext(): VercelRequestContext {
+  return {
+    headers: {},
+    telemetry: {
+      reportSpans: vi.fn(),
+      traceDrains: ["traceful.dev"],
+    },
+    url: "https://example.com",
+    waitUntil: vi.fn(),
+  };
+}
+
+function createSpan(
+  traceId = "0".repeat(32),
+  spanId = "0".repeat(16),
+): Span & ReadableSpan {
+  const spanContext = (): SpanContext => ({
+    spanId,
+    traceFlags: TraceFlags.SAMPLED,
+    traceId,
+  });
+  return { spanContext } as unknown as Span & ReadableSpan;
+}
+
+function createTraceId(value: number): string {
+  return value.toString(16).padStart(32, "0");
+}
+
+function createSpanId(value: number): string {
+  return value.toString(16).padStart(16, "0");
+}

--- a/packages/otel/src/processor/filter-when-drained-span-processor.ts
+++ b/packages/otel/src/processor/filter-when-drained-span-processor.ts
@@ -8,9 +8,12 @@ import { diag } from "@opentelemetry/api";
 import { isDraining } from "../vercel-request-context/is-draining";
 
 let reported = false;
+const MAX_DRAINED_SPAN_KEYS = 10_000;
 
 /** @internal */
 export class FilterWhenDrainedSpanProcessor implements SpanProcessor {
+  private readonly drainedSpanKeys = new Set<string>();
+
   constructor(private processor: SpanProcessor) {}
 
   forceFlush(): Promise<void> {
@@ -23,6 +26,14 @@ export class FilterWhenDrainedSpanProcessor implements SpanProcessor {
 
   onStart(span: Span, parentContext: Context): void {
     if (isDraining()) {
+      const spanKey = getSpanKey(span);
+      if (this.drainedSpanKeys.size >= MAX_DRAINED_SPAN_KEYS) {
+        const oldestSpanKey = this.drainedSpanKeys.values().next();
+        if (!oldestSpanKey.done) {
+          this.drainedSpanKeys.delete(oldestSpanKey.value);
+        }
+      }
+      this.drainedSpanKeys.add(spanKey);
       if (!reported) {
         reported = true;
         diag.debug(
@@ -35,9 +46,15 @@ export class FilterWhenDrainedSpanProcessor implements SpanProcessor {
   }
 
   onEnd(span: ReadableSpan): void {
-    if (isDraining()) {
+    const spanKey = getSpanKey(span);
+    if (this.drainedSpanKeys.delete(spanKey) || isDraining()) {
       return;
     }
     this.processor.onEnd(span);
   }
+}
+
+function getSpanKey(span: Span | ReadableSpan): string {
+  const { traceId, spanId } = span.spanContext();
+  return `${traceId}:${spanId}`;
 }

--- a/packages/otel/src/sdk.test.ts
+++ b/packages/otel/src/sdk.test.ts
@@ -1,0 +1,94 @@
+import { trace } from "@opentelemetry/api";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Sdk } from "./sdk";
+import type { VercelRequestContext } from "./vercel-request-context/api";
+
+const requestContextSymbol = Symbol.for("@vercel/request-context");
+const originalEnv = process.env;
+
+let activeContext: VercelRequestContext | undefined;
+
+beforeEach(() => {
+  activeContext = undefined;
+  process.env = { ...originalEnv };
+  delete process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
+  delete process.env.OTEL_EXPORTER_OTLP_HEADERS;
+  delete process.env.OTEL_EXPORTER_OTLP_PROTOCOL;
+  delete process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT;
+  delete process.env.OTEL_EXPORTER_OTLP_TRACES_HEADERS;
+  delete process.env.OTEL_EXPORTER_OTLP_TRACES_PROTOCOL;
+  delete process.env.VERCEL_OTEL_ENDPOINTS;
+  delete process.env.VERCEL_OTEL_ENDPOINTS_PORT;
+  delete process.env.VERCEL_OTEL_ENDPOINTS_PROTOCOL;
+  Reflect.set(globalThis, requestContextSymbol, {
+    get: () => activeContext,
+  });
+});
+
+afterEach(() => {
+  trace.disable();
+  vi.unstubAllGlobals();
+  Reflect.deleteProperty(globalThis, requestContextSymbol);
+  process.env = originalEnv;
+});
+
+describe("Sdk trace export", () => {
+  it("keeps automatic local OTLP export without trace drains", async () => {
+    const fetchMock = vi.fn(() => Promise.resolve(new Response()));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await exportOneSpan();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:4318/v1/traces",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("skips automatic local OTLP export when trace drains are configured", async () => {
+    activeContext = createDrainingContext();
+    const fetchMock = vi.fn(() => Promise.resolve(new Response()));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await exportOneSpan();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("skips automatic local OTLP export when trace drain context is lost before span end", async () => {
+    activeContext = createDrainingContext();
+    const fetchMock = vi.fn(() => Promise.resolve(new Response()));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await exportOneSpan(() => {
+      activeContext = undefined;
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+async function exportOneSpan(beforeEnd?: () => void): Promise<void> {
+  const sdk = new Sdk({
+    autoDetectResources: false,
+    instrumentations: [],
+    serviceName: "test-service",
+  });
+  sdk.start();
+  const span = trace.getTracer("test").startSpan("test span");
+  beforeEnd?.();
+  span.end();
+  await sdk.shutdown();
+}
+
+function createDrainingContext(): VercelRequestContext {
+  return {
+    headers: {},
+    telemetry: {
+      reportSpans: vi.fn(),
+      traceDrains: ["traceful.dev"],
+    },
+    url: "https://example.com",
+    waitUntil: vi.fn(),
+  };
+}


### PR DESCRIPTION
## Problem
- Drained traces can still hit local OTLP export if request context is lost before span end.

## Solution
- Remember drained span ids from `onStart` and skip them on `onEnd`.
- Add processor and SDK regression tests.