### PR TITLE
[@vercel/otel] Fix drained span local export

### DIFF
--- a/.changeset/0000-avoid-local-otlp-v2.md
+++ b/.changeset/0000-avoid-local-otlp-v2.md
@@ -1,0 +1,5 @@
+---
+"@vercel/otel": patch
+---
+
+Avoid local OTLP exports for drained Vercel traces when request context is lost before span end.

--- a/packages/otel/src/processor/filter-when-drained-span-processor.ts
+++ b/packages/otel/src/processor/filter-when-drained-span-processor.ts
@@ -8,9 +8,12 @@ import { diag } from "@opentelemetry/api";
 import { isDraining } from "../vercel-request-context/is-draining";
 
 let reported = false;
+const MAX_DRAINED_SPAN_KEYS = 10_000;
 
 /** @internal */
 export class FilterWhenDrainedSpanProcessor implements SpanProcessor {
+  private readonly drainedSpanKeys = new Set<string>();
+
   constructor(private processor: SpanProcessor) {}
 
   forceFlush(): Promise<void> {
@@ -23,6 +26,14 @@ export class FilterWhenDrainedSpanProcessor implements SpanProcessor {
 
   onStart(span: Span, parentContext: Context): void {
     if (isDraining()) {
+      const spanKey = getSpanKey(span);
+      if (this.drainedSpanKeys.size >= MAX_DRAINED_SPAN_KEYS) {
+        const oldestSpanKey = this.drainedSpanKeys.values().next();
+        if (!oldestSpanKey.done) {
+          this.drainedSpanKeys.delete(oldestSpanKey.value);
+        }
+      }
+      this.drainedSpanKeys.add(spanKey);
       if (!reported) {
         reported = true;
         diag.debug(
@@ -35,9 +46,15 @@ export class FilterWhenDrainedSpanProcessor implements SpanProcessor {
   }
 
   onEnd(span: ReadableSpan): void {
-    if (isDraining()) {
+    const spanKey = getSpanKey(span);
+    if (this.drainedSpanKeys.delete(spanKey) || isDraining()) {
       return;
     }
     this.processor.onEnd(span);
   }
+}
+
+function getSpanKey(span: Span | ReadableSpan): string {
+  const { traceId, spanId } = span.spanContext();
+  return `${traceId}:${spanId}`;
 }

--- a/packages/otel/src/sdk.test.ts
+++ b/packages/otel/src/sdk.test.ts
@@ -1,0 +1,95 @@
+import { trace } from "@opentelemetry/api";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Sdk } from "./sdk";
+import type { VercelRequestContext } from "./vercel-request-context/api";
+
+const requestContextSymbol = Symbol.for("@vercel/request-context");
+const originalEnv = process.env;
+
+let activeContext: VercelRequestContext | undefined;
+
+beforeEach(() => {
+  activeContext = undefined;
+  process.env = { ...originalEnv };
+  delete process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
+  delete process.env.OTEL_EXPORTER_OTLP_HEADERS;
+  delete process.env.OTEL_EXPORTER_OTLP_PROTOCOL;
+  delete process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT;
+  delete process.env.OTEL_EXPORTER_OTLP_TRACES_HEADERS;
+  delete process.env.OTEL_EXPORTER_OTLP_TRACES_PROTOCOL;
+  delete process.env.VERCEL_OTEL_ENDPOINTS;
+  delete process.env.VERCEL_OTEL_ENDPOINTS_PORT;
+  delete process.env.VERCEL_OTEL_ENDPOINTS_PROTOCOL;
+  Reflect.set(globalThis, requestContextSymbol, {
+    get: () => activeContext,
+  });
+});
+
+afterEach(() => {
+  trace.disable();
+  vi.unstubAllGlobals();
+  Reflect.deleteProperty(globalThis, requestContextSymbol);
+  process.env = originalEnv;
+});
+
+describe("Sdk trace export", () => {
+  it("keeps automatic local OTLP export without trace drains", async () => {
+    const fetchMock = vi.fn(() => Promise.resolve(new Response()));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await exportOneSpan();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:4318/v1/traces",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("skips automatic local OTLP export when trace drains are configured", async () => {
+    activeContext = createDrainingContext();
+    const fetchMock = vi.fn(() => Promise.resolve(new Response()));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await exportOneSpan();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("skips automatic local OTLP export when trace drain context is lost before span end", async () => {
+    activeContext = createDrainingContext();
+    const fetchMock = vi.fn(() => Promise.resolve(new Response()));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await exportOneSpan(() => {
+      activeContext = undefined;
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+});
+
+async function exportOneSpan(beforeEnd?: () => void): Promise<void> {
+  const sdk = new Sdk({
+    autoDetectResources: false,
+    instrumentations: [],
+    serviceName: "test-service",
+  });
+  sdk.start();
+  const span = trace.getTracer("test").startSpan("test span");
+  beforeEnd?.();
+  span.end();
+  await sdk.shutdown();
+}
+
+function createDrainingContext(): VercelRequestContext {
+  return {
+    headers: {},
+    telemetry: {
+      reportSpans: vi.fn(),
+      traceDrains: ["traceful.dev"],
+    },
+    url: "https://example.com",
+    waitUntil: vi.fn(),
+  };
+}


### PR DESCRIPTION
## Problem
- Drained spans can still hit automatic local OTLP export if request context is lost before span end.

## Solution
- Remember drained span ids at start and skip their local export at end.
- Cap remembered ids at 10k.
- Add SDK-level coverage.