### PR TITLE
chore: fix v1 release pnpm setup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,8 +36,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 11.8.0
 
       - uses: actions/setup-node@v4
         with:
@@ -73,8 +71,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 11.8.0
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Problem
- v1 [release workflow fails](https://github.com/vercel/otel/actions/runs/27784770764/job/82218536018) in `pnpm/action-setup@v4`.
- Workflow set `version: 11.8.0` while `package.json` pins `pnpm@9.4.0`.
- Pushing to `v1.x` should not trigger a release automatically.

## Solution
- Remove explicit pnpm action version.
- Keep package manager pinned to `pnpm@9.4.0`.
- Keep release jobs on Node 22.
- Keep releases manual-only via `workflow_dispatch`.

## Related PR(s)
- #208