### PR TITLE
chore: use Node 24 for v1 release (fix OIDC publish E404)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22.14.0
+          node-version: 24 # bundles npm >=11.5.1, required for OIDC trusted publishing
           cache: "pnpm"
           registry-url: "https://registry.npmjs.org"
 
@@ -74,7 +74,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22.14.0
+          node-version: 24 # bundles npm >=11.5.1, required for OIDC trusted publishing
           cache: "pnpm"
           registry-url: "https://registry.npmjs.org"
 


### PR DESCRIPTION
## Problem

The v1.x `Release` workflow fails at publish with:

```
🦋 error E404 Not Found - PUT https://registry.npmjs.org/@vercel%2fotel
```

`E404 on PUT` is npm's masked response for an **unauthenticated** publish. (`1.14.2` was never published — `otel-sdk-1` is still at `1.14.1`.)

## Root cause

Releases use OIDC **trusted publishing** (no `NPM_TOKEN`). `changesets/action` detects OIDC but defers the actual OIDC→registry-token exchange to the **npm CLI**, which requires **npm ≥ 11.5.1**.

v1.x pinned `node-version: 22.14.0`, and **every Node 22 release bundles npm 10.9.x** (< 11.5.1) → npm can't perform the OIDC exchange → publishes anonymously → E404.

The `main` release workflow is identical (same `pnpm@9.4.0`, same `changesets/action` OIDC path, same `.npmrc`) and publishes fine — because it runs Node 24 (npm 11.6.2+). That passing run isolates the Node/npm version as the only material difference. The `22.14.0` pin likely came from misreading npm's "requires Node.js ≥ 22.14.0" (npm 11.5.1 *runs on* Node ≥22.14; Node 22.14 does not *ship* npm 11.5.1).

## Fix

Bump both release jobs to `node-version: 24` (npm 11.6.2+). Can't use `.node-version` here — that's `lts/hydrogen` (Node 18, the v1 SDK's runtime target); the publish job's Node is just tooling and is independent of the package's supported runtimes.