### PR TITLE
fix(otel): flush spans in-context to prevent span loss in long-running invocations

### DIFF
--- a/.changeset/0000-fix-workflow-span-context-loss.md
+++ b/.changeset/0000-fix-workflow-span-context-loss.md
@@ -2,4 +2,4 @@
 "@vercel/otel": patch
 ---
 
-Fix long-running (e.g. Vercel Workflow) traces dropping spans from the first half of the run. Periodic span flushes now run inside the request context instead of relying on the BatchSpanProcessor's wall-clock timer (which escaped the request's AsyncLocalStorage), and the runtime exporter now retains and retries batches instead of silently dropping them when the request context is momentarily unavailable.
+Fix long-running (e.g. Vercel Workflow) traces dropping spans from the first half of the run. Periodic span flushes now run inside the request context instead of relying on the BatchSpanProcessor's wall-clock timer (which escaped the request's AsyncLocalStorage), the runtime exporter routes each trace's spans through the request context that owns them (so concurrent invocations on one instance no longer misreport each other's spans), and it retains and retries batches instead of silently dropping them when the request context is momentarily unavailable.

--- a/.changeset/0000-fix-workflow-span-context-loss.md
+++ b/.changeset/0000-fix-workflow-span-context-loss.md
@@ -1,0 +1,5 @@
+---
+"@vercel/otel": patch
+---
+
+Fix long-running (e.g. Vercel Workflow) traces dropping spans from the first half of the run. Periodic span flushes now run inside the request context instead of relying on the BatchSpanProcessor's wall-clock timer (which escaped the request's AsyncLocalStorage), and the runtime exporter now retains and retries batches instead of silently dropping them when the request context is momentarily unavailable.

--- a/packages/otel/build.ts
+++ b/packages/otel/build.ts
@@ -6,8 +6,8 @@ const MINIFY = true;
 const SOURCEMAP = true;
 
 const MAX_SIZES = {
-  "dist/node/index.js": 300_000, // Increased from original 217KB limit
-  "dist/edge/index.js": 191_000, // Increased from original 185KB limit
+  "dist/node/index.js": 302_000, // Increased from original 217KB limit
+  "dist/edge/index.js": 193_000, // Increased from original 185KB limit
 };
 
 type ExternalPluginFactory = (external: string[]) => Plugin;

--- a/packages/otel/src/processor/composite-span-processor.test.ts
+++ b/packages/otel/src/processor/composite-span-processor.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ReadableSpan, SpanProcessor } from "@opentelemetry/sdk-trace-base";
+import { hrTime } from "@opentelemetry/core";
+import { TraceFlags, SpanKind, SpanStatusCode } from "@opentelemetry/api";
+import { resourceFromAttributes } from "@opentelemetry/resources";
+import type { VercelRequestContext } from "../vercel-request-context/api";
+import { CompositeSpanProcessor } from "./composite-span-processor";
+
+const VRC_SYMBOL = Symbol.for("@vercel/request-context");
+type GlobalWithReader = Record<symbol, unknown>;
+
+function installContext(ctx: VercelRequestContext | undefined): void {
+  (globalThis as GlobalWithReader)[VRC_SYMBOL] = { get: () => ctx };
+}
+
+function fakeVrc(): VercelRequestContext {
+  return {
+    waitUntil: () => undefined,
+    headers: {},
+    url: "https://example.com",
+    telemetry: { reportSpans: () => undefined },
+  };
+}
+
+function createChildSpan(spanId: string): ReadableSpan {
+  const spanContext = {
+    traceId: "ee75cd9e534ff5e9ed78b4a0c706f0f2",
+    spanId,
+    traceFlags: TraceFlags.SAMPLED,
+    isRemote: false,
+  };
+  return {
+    name: `span-${spanId}`,
+    kind: SpanKind.INTERNAL,
+    spanContext: () => spanContext,
+    parentSpanContext: {
+      spanId: "7e2a325411bdc191",
+      traceId: "ee75cd9e534ff5e9ed78b4a0c706f0f2",
+      traceFlags: TraceFlags.SAMPLED,
+    },
+    startTime: hrTime(1),
+    endTime: hrTime(2),
+    status: { code: SpanStatusCode.UNSET },
+    attributes: {},
+    links: [],
+    events: [],
+    duration: hrTime(1),
+    ended: true,
+    resource: resourceFromAttributes({}),
+    instrumentationScope: { name: "default" },
+    droppedAttributesCount: 0,
+    droppedEventsCount: 0,
+    droppedLinksCount: 0,
+  };
+}
+
+function fakeProcessor(): {
+  processor: SpanProcessor;
+  forceFlush: ReturnType<typeof vi.fn>;
+} {
+  const forceFlush = vi.fn().mockResolvedValue(undefined);
+  const processor: SpanProcessor = {
+    onStart: vi.fn(),
+    onEnd: vi.fn(),
+    forceFlush,
+    shutdown: vi.fn().mockResolvedValue(undefined),
+  };
+  return { processor, forceFlush };
+}
+
+describe("CompositeSpanProcessor in-context flush", () => {
+  afterEach(() => {
+    installContext(undefined);
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it("flushes once the batch-size threshold of ended spans is reached", () => {
+    installContext(fakeVrc());
+    vi.stubEnv("OTEL_BSP_MAX_EXPORT_BATCH_SIZE", "3");
+    const { processor: downstream, forceFlush } = fakeProcessor();
+    const processor = new CompositeSpanProcessor([downstream], undefined);
+
+    processor.onEnd(createChildSpan("0000000000000001"));
+    processor.onEnd(createChildSpan("0000000000000002"));
+    expect(forceFlush).toHaveBeenCalledTimes(0);
+
+    processor.onEnd(createChildSpan("0000000000000003"));
+    expect(forceFlush).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not flush off-Vercel (no request context)", () => {
+    installContext(undefined);
+    vi.stubEnv("OTEL_BSP_MAX_EXPORT_BATCH_SIZE", "3");
+    const { processor: downstream, forceFlush } = fakeProcessor();
+    const processor = new CompositeSpanProcessor([downstream], undefined);
+
+    for (let i = 1; i <= 5; i++) {
+      processor.onEnd(createChildSpan(`00000000000000${i}0`));
+    }
+    expect(forceFlush).toHaveBeenCalledTimes(0);
+  });
+
+  it("flushes once the schedule-delay elapses between ended spans", () => {
+    installContext(fakeVrc());
+    vi.stubEnv("OTEL_BSP_MAX_EXPORT_BATCH_SIZE", "1000000");
+    vi.stubEnv("OTEL_BSP_SCHEDULE_DELAY", "5000");
+    const { processor: downstream, forceFlush } = fakeProcessor();
+    const processor = new CompositeSpanProcessor([downstream], undefined);
+
+    const now = vi.spyOn(Date, "now");
+
+    now.mockReturnValue(1000);
+    processor.onEnd(createChildSpan("0000000000000001"));
+    now.mockReturnValue(1000);
+    processor.onEnd(createChildSpan("0000000000000002"));
+    expect(forceFlush).toHaveBeenCalledTimes(0);
+
+    now.mockReturnValue(7000);
+    processor.onEnd(createChildSpan("0000000000000003"));
+    expect(forceFlush).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/otel/src/processor/composite-span-processor.ts
+++ b/packages/otel/src/processor/composite-span-processor.ts
@@ -8,6 +8,10 @@ import type {
 import { getNumberFromEnv } from "@opentelemetry/core";
 import { getVercelRequestContext } from "../vercel-request-context/api";
 import { getVercelRequestContextAttributes } from "../vercel-request-context/attributes";
+import {
+  deleteRequestContext,
+  setRequestContext,
+} from "../vercel-request-context/context-registry";
 import { isSampled } from "../util/sampled";
 import type { AttributesFromHeaders } from "../types";
 
@@ -68,6 +72,7 @@ export class CompositeSpanProcessor implements SpanProcessor {
 
       // Flush the streams to avoid data loss.
       if (vrc) {
+        setRequestContext(traceId, vrc);
         vrc.waitUntil(async () => {
           if (this.rootSpanIds.has(traceId)) {
             // Not root has not completed yet, so no point in flushing.
@@ -89,7 +94,10 @@ export class CompositeSpanProcessor implements SpanProcessor {
               clearTimeout(timer);
             }
           }
-          return this.forceFlush();
+          await this.forceFlush();
+          // The invocation is over; the channel can no longer accept spans and
+          // the entry would leak if the root span never ended.
+          deleteRequestContext(traceId);
         });
       }
     }

--- a/packages/otel/src/processor/composite-span-processor.ts
+++ b/packages/otel/src/processor/composite-span-processor.ts
@@ -5,6 +5,7 @@ import type {
   ReadableSpan,
   SpanProcessor,
 } from "@opentelemetry/sdk-trace-base";
+import { getNumberFromEnv } from "@opentelemetry/core";
 import { getVercelRequestContext } from "../vercel-request-context/api";
 import { getVercelRequestContextAttributes } from "../vercel-request-context/attributes";
 import { isSampled } from "../util/sampled";
@@ -17,6 +18,13 @@ export class CompositeSpanProcessor implements SpanProcessor {
     { rootSpanId: string; open: Span[] }
   >();
   private readonly waitSpanEnd = new Map<string, () => void>();
+
+  private readonly flushBatchSize =
+    getNumberFromEnv("OTEL_BSP_MAX_EXPORT_BATCH_SIZE") ?? 512;
+  private readonly flushDelayMs =
+    getNumberFromEnv("OTEL_BSP_SCHEDULE_DELAY") ?? 5000;
+  private spansSinceFlush = 0;
+  private lastFlushMs = 0;
 
   constructor(
     private processors: SpanProcessor[],
@@ -135,6 +143,32 @@ export class CompositeSpanProcessor implements SpanProcessor {
         this.waitSpanEnd.delete(traceId);
         pending();
       }
+    } else if (sampled && getVercelRequestContext()) {
+      // Periodic in-context flush, Vercel-only. onEnd runs inside the request's
+      // async context, so this flush (unlike the BatchSpanProcessor's bare-setTimeout
+      // timer) can resolve the Vercel request context and actually export. Off-Vercel
+      // there is no request context to lose, so we skip and let the stock
+      // BatchSpanProcessor timer flush as before (no behavior change). The root span's
+      // flush is already handled by the waitUntil in onStart.
+      this.maybeFlush();
+    }
+  }
+
+  private maybeFlush(): void {
+    this.spansSinceFlush += 1;
+    const now = Date.now();
+    if (this.lastFlushMs === 0) {
+      this.lastFlushMs = now;
+    }
+    if (
+      this.spansSinceFlush >= this.flushBatchSize ||
+      now - this.lastFlushMs >= this.flushDelayMs
+    ) {
+      this.spansSinceFlush = 0;
+      this.lastFlushMs = now;
+      void this.forceFlush().catch((e) => {
+        diag.error("@vercel/otel: periodic flush failed:", e);
+      });
     }
   }
 }

--- a/packages/otel/src/vercel-request-context/context-registry.ts
+++ b/packages/otel/src/vercel-request-context/context-registry.ts
@@ -1,0 +1,33 @@
+import type { VercelRequestContext } from "./api";
+
+/**
+ * Per-traceId capture of the owning Vercel request context.
+ *
+ * Captured in `CompositeSpanProcessor.onStart` (which always runs in-request)
+ * and used by the exporter to route each trace's spans through the request
+ * that owns them. Concurrent invocations on one instance share the exporter,
+ * and the runtime drops spans reported through a foreign invocation's channel.
+ *
+ * @internal
+ */
+const registry = new Map<string, VercelRequestContext>();
+
+/** @internal */
+export function setRequestContext(
+  traceId: string,
+  context: VercelRequestContext,
+): void {
+  registry.set(traceId, context);
+}
+
+/** @internal */
+export function getRequestContext(
+  traceId: string,
+): VercelRequestContext | undefined {
+  return registry.get(traceId);
+}
+
+/** @internal */
+export function deleteRequestContext(traceId: string): void {
+  registry.delete(traceId);
+}

--- a/packages/otel/src/vercel-request-context/exporter.test.ts
+++ b/packages/otel/src/vercel-request-context/exporter.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ReadableSpan } from "@opentelemetry/sdk-trace-base";
+import { ExportResultCode, hrTime } from "@opentelemetry/core";
+import { diag, TraceFlags, SpanKind, SpanStatusCode } from "@opentelemetry/api";
+import type { IExportTraceServiceRequest } from "@opentelemetry/otlp-transformer/build/src/trace/internal-types";
+import { resourceFromAttributes } from "@opentelemetry/resources";
+import type { VercelRequestContext } from "./api";
+import { VercelRuntimeSpanExporter } from "./exporter";
+
+const TRACE_ID = "ee75cd9e534ff5e9ed78b4a0c706f0f2";
+const VRC_SYMBOL = Symbol.for("@vercel/request-context");
+
+type GlobalWithReader = Record<symbol, unknown>;
+
+function createSpan(spanId: string, traceId = TRACE_ID): ReadableSpan {
+  const spanContext = {
+    traceId,
+    spanId,
+    traceFlags: TraceFlags.SAMPLED,
+    isRemote: false,
+  };
+  return {
+    name: `span-${spanId}`,
+    kind: SpanKind.INTERNAL,
+    spanContext: () => spanContext,
+    parentSpanContext: undefined,
+    startTime: hrTime(1),
+    endTime: hrTime(2),
+    status: { code: SpanStatusCode.UNSET },
+    attributes: {},
+    links: [],
+    events: [],
+    duration: hrTime(1),
+    ended: true,
+    resource: resourceFromAttributes({}),
+    instrumentationScope: { name: "default" },
+    droppedAttributesCount: 0,
+    droppedEventsCount: 0,
+    droppedLinksCount: 0,
+  };
+}
+
+function makeContext(): {
+  ctx: VercelRequestContext;
+  reportSpans: ReturnType<typeof vi.fn>;
+} {
+  const reportSpans = vi.fn();
+  const ctx: VercelRequestContext = {
+    waitUntil: () => undefined,
+    headers: {},
+    url: "https://example.com",
+    telemetry: { reportSpans },
+  };
+  return { ctx, reportSpans };
+}
+
+function installContext(ctx: VercelRequestContext | undefined): void {
+  (globalThis as GlobalWithReader)[VRC_SYMBOL] = { get: () => ctx };
+}
+
+function countSpans(reportSpans: ReturnType<typeof vi.fn>, call = 0): number {
+  const data = reportSpans.mock.calls[call]?.[0] as IExportTraceServiceRequest;
+  return (data.resourceSpans ?? []).reduce(
+    (total, rs) =>
+      total +
+      rs.scopeSpans.reduce((n, ss) => n + (ss.spans ?? []).length, 0),
+    0,
+  );
+}
+
+describe("VercelRuntimeSpanExporter", () => {
+  afterEach(() => {
+    installContext(undefined);
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it("retains spans when the context is missing and re-ships them on the next in-context flush", () => {
+    const exporter = new VercelRuntimeSpanExporter();
+
+    installContext(undefined);
+    const firstResult = vi.fn();
+    exporter.export([createSpan("0000000000000001")], firstResult);
+    expect(firstResult).toHaveBeenCalledWith({
+      code: ExportResultCode.SUCCESS,
+      error: undefined,
+    });
+
+    const { ctx, reportSpans } = makeContext();
+    installContext(ctx);
+    const secondResult = vi.fn();
+    exporter.export([createSpan("0000000000000002")], secondResult);
+
+    // Retained spans ship in their own batch, ahead of the incoming batch.
+    expect(reportSpans).toHaveBeenCalledTimes(2);
+    expect(countSpans(reportSpans, 0)).toBe(1);
+    expect(countSpans(reportSpans, 1)).toBe(1);
+  });
+
+  it("drops oldest spans and warns once the retained buffer is full", () => {
+    vi.stubEnv("OTEL_BSP_MAX_QUEUE_SIZE", "2");
+    const warn = vi.spyOn(diag, "warn");
+    const exporter = new VercelRuntimeSpanExporter();
+
+    installContext(undefined);
+    exporter.export(
+      [
+        createSpan("0000000000000001"),
+        createSpan("0000000000000002"),
+        createSpan("0000000000000003"),
+      ],
+      vi.fn(),
+    );
+    expect(warn).toHaveBeenCalled();
+
+    const { ctx, reportSpans } = makeContext();
+    installContext(ctx);
+    exporter.export([], vi.fn());
+    expect(countSpans(reportSpans)).toBe(2);
+  });
+
+  it("re-retains pending spans when re-shipping them fails, without failing the incoming batch", () => {
+    const exporter = new VercelRuntimeSpanExporter();
+
+    installContext(undefined);
+    exporter.export([createSpan("0000000000000001")], vi.fn());
+
+    const { ctx, reportSpans } = makeContext();
+    reportSpans.mockImplementationOnce(() => {
+      throw new Error("boom");
+    });
+    installContext(ctx);
+    const result = vi.fn();
+    exporter.export([createSpan("0000000000000002")], result);
+
+    expect(result).toHaveBeenCalledWith({
+      code: ExportResultCode.SUCCESS,
+      error: undefined,
+    });
+    expect(reportSpans).toHaveBeenCalledTimes(2);
+    expect(countSpans(reportSpans, 1)).toBe(1);
+
+    // The failed pending span ships on the next flush.
+    exporter.export([createSpan("0000000000000003")], vi.fn());
+    expect(reportSpans).toHaveBeenCalledTimes(4);
+    expect(countSpans(reportSpans, 2)).toBe(1);
+    expect(countSpans(reportSpans, 3)).toBe(1);
+  });
+});

--- a/packages/otel/src/vercel-request-context/exporter.test.ts
+++ b/packages/otel/src/vercel-request-context/exporter.test.ts
@@ -6,8 +6,10 @@ import type { IExportTraceServiceRequest } from "@opentelemetry/otlp-transformer
 import { resourceFromAttributes } from "@opentelemetry/resources";
 import type { VercelRequestContext } from "./api";
 import { VercelRuntimeSpanExporter } from "./exporter";
+import { deleteRequestContext, setRequestContext } from "./context-registry";
 
 const TRACE_ID = "ee75cd9e534ff5e9ed78b4a0c706f0f2";
+const OTHER_TRACE_ID = "aa75cd9e534ff5e9ed78b4a0c706f0f2";
 const VRC_SYMBOL = Symbol.for("@vercel/request-context");
 
 type GlobalWithReader = Record<symbol, unknown>;
@@ -71,6 +73,8 @@ function countSpans(reportSpans: ReturnType<typeof vi.fn>, call = 0): number {
 describe("VercelRuntimeSpanExporter", () => {
   afterEach(() => {
     installContext(undefined);
+    deleteRequestContext(TRACE_ID);
+    deleteRequestContext(OTHER_TRACE_ID);
     vi.unstubAllEnvs();
     vi.restoreAllMocks();
   });
@@ -91,10 +95,8 @@ describe("VercelRuntimeSpanExporter", () => {
     const secondResult = vi.fn();
     exporter.export([createSpan("0000000000000002")], secondResult);
 
-    // Retained spans ship in their own batch, ahead of the incoming batch.
-    expect(reportSpans).toHaveBeenCalledTimes(2);
-    expect(countSpans(reportSpans, 0)).toBe(1);
-    expect(countSpans(reportSpans, 1)).toBe(1);
+    expect(reportSpans).toHaveBeenCalledTimes(1);
+    expect(countSpans(reportSpans)).toBe(2);
   });
 
   it("drops oldest spans and warns once the retained buffer is full", () => {
@@ -119,11 +121,34 @@ describe("VercelRuntimeSpanExporter", () => {
     expect(countSpans(reportSpans)).toBe(2);
   });
 
-  it("re-retains pending spans when re-shipping them fails, without failing the incoming batch", () => {
+  it("routes each trace's spans through its owning request context", () => {
     const exporter = new VercelRuntimeSpanExporter();
+    const { ctx: owner, reportSpans: ownerReport } = makeContext();
+    setRequestContext(TRACE_ID, owner);
 
-    installContext(undefined);
-    exporter.export([createSpan("0000000000000001")], vi.fn());
+    const { ctx: ambient, reportSpans: ambientReport } = makeContext();
+    installContext(ambient);
+    const result = vi.fn();
+    exporter.export(
+      [
+        createSpan("0000000000000001", TRACE_ID),
+        createSpan("0000000000000002", OTHER_TRACE_ID),
+      ],
+      result,
+    );
+
+    expect(result).toHaveBeenCalledWith({
+      code: ExportResultCode.SUCCESS,
+      error: undefined,
+    });
+    expect(ownerReport).toHaveBeenCalledTimes(1);
+    expect(countSpans(ownerReport)).toBe(1);
+    expect(ambientReport).toHaveBeenCalledTimes(1);
+    expect(countSpans(ambientReport)).toBe(1);
+  });
+
+  it("re-retains a failed group without losing it or failing the export", () => {
+    const exporter = new VercelRuntimeSpanExporter();
 
     const { ctx, reportSpans } = makeContext();
     reportSpans.mockImplementationOnce(() => {
@@ -131,19 +156,17 @@ describe("VercelRuntimeSpanExporter", () => {
     });
     installContext(ctx);
     const result = vi.fn();
-    exporter.export([createSpan("0000000000000002")], result);
+    exporter.export([createSpan("0000000000000001")], result);
 
     expect(result).toHaveBeenCalledWith({
       code: ExportResultCode.SUCCESS,
       error: undefined,
     });
-    expect(reportSpans).toHaveBeenCalledTimes(2);
-    expect(countSpans(reportSpans, 1)).toBe(1);
+    expect(reportSpans).toHaveBeenCalledTimes(1);
 
-    // The failed pending span ships on the next flush.
-    exporter.export([createSpan("0000000000000003")], vi.fn());
-    expect(reportSpans).toHaveBeenCalledTimes(4);
-    expect(countSpans(reportSpans, 2)).toBe(1);
-    expect(countSpans(reportSpans, 3)).toBe(1);
+    // The failed span ships together with the next batch.
+    exporter.export([createSpan("0000000000000002")], vi.fn());
+    expect(reportSpans).toHaveBeenCalledTimes(2);
+    expect(countSpans(reportSpans, 1)).toBe(2);
   });
 });

--- a/packages/otel/src/vercel-request-context/exporter.ts
+++ b/packages/otel/src/vercel-request-context/exporter.ts
@@ -1,40 +1,71 @@
 import { diag } from "@opentelemetry/api";
 import type { ReadableSpan, SpanExporter } from "@opentelemetry/sdk-trace-base";
-import { ExportResultCode, type ExportResult } from "@opentelemetry/core";
+import {
+  ExportResultCode,
+  getNumberFromEnv,
+  type ExportResult,
+} from "@opentelemetry/core";
 import { JsonTraceSerializer } from "@opentelemetry/otlp-transformer/build/src/trace/json/trace";
 import type { IExportTraceServiceRequest } from "@opentelemetry/otlp-transformer/build/src/trace/internal-types";
-import { getVercelRequestContext } from "./api";
+import { getVercelRequestContext, type VercelRequestContext } from "./api";
 
 export class VercelRuntimeSpanExporter implements SpanExporter {
+  private pendingSpans: ReadableSpan[] = [];
+  private droppedSpansCount = 0;
+  private readonly maxBufferSize =
+    getNumberFromEnv("OTEL_BSP_MAX_QUEUE_SIZE") ?? 2048;
+
   export(
     spans: ReadableSpan[],
     resultCallback: (result: ExportResult) => void,
   ): void {
     const context = getVercelRequestContext();
+
     if (!context?.telemetry) {
-      diag.warn("@vercel/otel: no telemetry context found");
+      // No ambient context (e.g. a bare-setTimeout timer flush). Shipping via a
+      // context captured earlier is unreliable (the runtime may ack but never
+      // land the spans), so retain and let the next in-context flush re-ship.
+      diag.debug(
+        "@vercel/otel: no telemetry context found; retaining spans for the next in-context flush",
+      );
+      this.retain(spans);
       resultCallback({ code: ExportResultCode.SUCCESS, error: undefined });
       return;
     }
 
-    try {
-      const serializedData = JsonTraceSerializer.serializeRequest(spans);
-
-      if (!serializedData) {
-        throw new Error("Failed to serialize spans");
+    // Ship previously-retained spans separately so a failing retained batch
+    // neither fails the incoming batch nor gets lost.
+    if (this.pendingSpans.length > 0) {
+      const pending = this.pendingSpans;
+      this.pendingSpans = [];
+      try {
+        reportSpans(context.telemetry, pending);
+      } catch (e) {
+        this.retain(pending);
+        diag.warn("@vercel/otel: failed to re-ship retained spans:", e);
       }
-      // Convert back to object format for the Vercel telemetry API
-      const data = JSON.parse(
-        new TextDecoder().decode(serializedData),
-      ) as IExportTraceServiceRequest;
+    }
 
-      context.telemetry.reportSpans(data);
+    try {
+      reportSpans(context.telemetry, spans);
       resultCallback({ code: ExportResultCode.SUCCESS, error: undefined });
     } catch (e) {
       resultCallback({
         code: ExportResultCode.FAILED,
         error: e instanceof Error ? e : new Error(String(e)),
       });
+    }
+  }
+
+  private retain(spans: ReadableSpan[]): void {
+    this.pendingSpans.push(...spans);
+    const overflow = this.pendingSpans.length - this.maxBufferSize;
+    if (overflow > 0) {
+      this.pendingSpans.splice(0, overflow);
+      this.droppedSpansCount += overflow;
+      diag.warn(
+        `@vercel/otel: retained span buffer full, dropped ${this.droppedSpansCount} span(s) total`,
+      );
     }
   }
 
@@ -45,4 +76,19 @@ export class VercelRuntimeSpanExporter implements SpanExporter {
   forceFlush?(): Promise<void> {
     return Promise.resolve();
   }
+}
+
+function reportSpans(
+  telemetry: NonNullable<VercelRequestContext["telemetry"]>,
+  spans: ReadableSpan[],
+): void {
+  const serializedData = JsonTraceSerializer.serializeRequest(spans);
+  if (!serializedData) {
+    throw new Error("Failed to serialize spans");
+  }
+  // Convert back to object format for the Vercel telemetry API
+  const data = JSON.parse(
+    new TextDecoder().decode(serializedData),
+  ) as IExportTraceServiceRequest;
+  telemetry.reportSpans(data);
 }

--- a/packages/otel/src/vercel-request-context/exporter.ts
+++ b/packages/otel/src/vercel-request-context/exporter.ts
@@ -8,6 +8,7 @@ import {
 import { JsonTraceSerializer } from "@opentelemetry/otlp-transformer/build/src/trace/json/trace";
 import type { IExportTraceServiceRequest } from "@opentelemetry/otlp-transformer/build/src/trace/internal-types";
 import { getVercelRequestContext, type VercelRequestContext } from "./api";
+import { getRequestContext } from "./context-registry";
 
 export class VercelRuntimeSpanExporter implements SpanExporter {
   private pendingSpans: ReadableSpan[] = [];
@@ -19,12 +20,13 @@ export class VercelRuntimeSpanExporter implements SpanExporter {
     spans: ReadableSpan[],
     resultCallback: (result: ExportResult) => void,
   ): void {
-    const context = getVercelRequestContext();
+    const ambient = getVercelRequestContext();
 
-    if (!context?.telemetry) {
-      // No ambient context (e.g. a bare-setTimeout timer flush). Shipping via a
-      // context captured earlier is unreliable (the runtime may ack but never
-      // land the spans), so retain and let the next in-context flush re-ship.
+    if (!ambient?.telemetry) {
+      // No ambient context (e.g. a bare-setTimeout timer flush). Reporting from
+      // outside a request is unreliable even through a captured context (the
+      // runtime may ack but never land the spans), so retain and let the next
+      // in-context flush ship.
       diag.debug(
         "@vercel/otel: no telemetry context found; retaining spans for the next in-context flush",
       );
@@ -33,28 +35,29 @@ export class VercelRuntimeSpanExporter implements SpanExporter {
       return;
     }
 
-    // Ship previously-retained spans separately so a failing retained batch
-    // neither fails the incoming batch nor gets lost.
-    if (this.pendingSpans.length > 0) {
-      const pending = this.pendingSpans;
-      this.pendingSpans = [];
+    // Route each trace's spans through its owning request context (captured at
+    // root onStart). Concurrent invocations on one instance share this exporter,
+    // and the runtime drops spans reported through a foreign invocation's
+    // channel. Failed groups are retained for the next flush, never lost.
+    const batch =
+      this.pendingSpans.length > 0 ? [...this.pendingSpans, ...spans] : spans;
+    this.pendingSpans = [];
+    const ambientTelemetry = ambient.telemetry;
+    const remaining: ReadableSpan[] = [];
+    groupByTraceId(batch).forEach((group, traceId) => {
+      const telemetry =
+        getRequestContext(traceId)?.telemetry ?? ambientTelemetry;
       try {
-        reportSpans(context.telemetry, pending);
+        reportSpans(telemetry, group);
       } catch (e) {
-        this.retain(pending);
-        diag.warn("@vercel/otel: failed to re-ship retained spans:", e);
+        diag.warn("@vercel/otel: reportSpans failed; retaining spans:", e);
+        remaining.push(...group);
       }
+    });
+    if (remaining.length > 0) {
+      this.retain(remaining);
     }
-
-    try {
-      reportSpans(context.telemetry, spans);
-      resultCallback({ code: ExportResultCode.SUCCESS, error: undefined });
-    } catch (e) {
-      resultCallback({
-        code: ExportResultCode.FAILED,
-        error: e instanceof Error ? e : new Error(String(e)),
-      });
-    }
+    resultCallback({ code: ExportResultCode.SUCCESS, error: undefined });
   }
 
   private retain(spans: ReadableSpan[]): void {
@@ -91,4 +94,18 @@ function reportSpans(
     new TextDecoder().decode(serializedData),
   ) as IExportTraceServiceRequest;
   telemetry.reportSpans(data);
+}
+
+function groupByTraceId(spans: ReadableSpan[]): Map<string, ReadableSpan[]> {
+  const byTrace = new Map<string, ReadableSpan[]>();
+  for (const span of spans) {
+    const { traceId } = span.spanContext();
+    const group = byTrace.get(traceId);
+    if (group) {
+      group.push(span);
+    } else {
+      byTrace.set(traceId, [span]);
+    }
+  }
+  return byTrace;
 }


### PR DESCRIPTION
## Problem

Traces from long-running invocations (e.g. Vercel Workflows) are missing most spans from the first part of the run: the trace looks blank early on, with all step spans bunched up near the end. The work happens the whole time — the spans are genuinely lost.

## Root cause

Two flaws stack up:

1. **Flush scheduling is wall-clock.** The `BatchSpanProcessor` schedules flushes with a bare `setTimeout` (`OTEL_BSP_SCHEDULE_DELAY`, default 5s), which escapes the request's `AsyncLocalStorage`. When the timer fires, `getVercelRequestContext()` returns `undefined`.
2. **The exporter failed silently.** `VercelRuntimeSpanExporter` treated a missing context as success: it acked the batch (`ExportResultCode.SUCCESS`) and dropped the spans without exporting anything.

Net effect: every timer flush before the end of the invocation throws its spans away. Only the final flush — triggered via `waitUntil`, which runs inside the request context — survives, so only the last few seconds of spans land. Verified: disabling the timer (`OTEL_BSP_SCHEDULE_DELAY=600000`) makes all spans survive on a long run.

## Fix

1. **In-context periodic flush** (`CompositeSpanProcessor.onEnd`): `span.end()` always runs inside the request's async context, so the processor now triggers a debounced `forceFlush()` from there — when ≥ `OTEL_BSP_MAX_EXPORT_BATCH_SIZE` (512) spans have ended or ≥ `OTEL_BSP_SCHEDULE_DELAY` (5000ms) has elapsed since the last flush. This replaces the escaping wall-clock timer as the effective flush driver. Vercel-only: off-platform there is no request context to lose, and behavior is unchanged.
2. **Per-trace span routing** (`VercelRuntimeSpanExporter`): concurrent invocations on one function instance share the batch queue, and the runtime drops spans reported through a foreign invocation's channel — so flushing the whole queue through the ambient request's `reportSpans` loses the other invocations' spans (observed on warm instances). The `CompositeSpanProcessor` now captures the owning `VercelRequestContext` per trace id at root-span start, and the exporter groups each batch by trace id and ships every group through its owning context (falling back to the ambient one), deleting the entry after the invocation's final flush.
3. **The exporter never silently drops**: batches that arrive without any request context, or groups whose `reportSpans` throws, are retained in a bounded buffer (`OTEL_BSP_MAX_QUEUE_SIZE`, default 2048; oldest dropped with a warning on overflow) and re-shipped with the next in-context flush.

Reusing the standard `OTEL_BSP_*` env vars keeps the existing knobs meaningful for both mechanisms.

## Known residual

Spans retained after an invocation's final flush (their registry entry is gone by then) fall back to the next invocation's ambient context on a reused function instance, which the runtime may drop. Better than losing them silently, but confirmation from the runtime team on cross-invocation `reportSpans` semantics would settle it. A deeper fix (making `reportSpans` reachable without the request ALS) is runtime-side and out of scope here.

## Testing

- Unit tests for the debounced in-context flush (batch-size trigger, delay trigger, off-Vercel no-op) and the exporter routing/retain/re-ship/re-retain paths
- `type-check`, `eslint`, full unit suite pass
- [ ] Re-validate against a real long-running workflow deployment (all step spans land with default env)

