### PR TITLE
fix(otel): ship each trace's spans in one report through its owning request context

### DIFF
--- a/.changeset/fix-span-context-routing.md
+++ b/.changeset/fix-span-context-routing.md
@@ -1,0 +1,5 @@
+---
+"@vercel/otel": patch
+---
+
+Fix long-running invocations (e.g. Vercel Workflows) losing most spans from the first part of the run. The runtime only reliably persists one `reportSpans` payload per invocation, delivered through that invocation's own request context, while the BatchSpanProcessor flushed many times mid-run (from a bare `setTimeout` outside the request's AsyncLocalStorage) and shipped whole batches through whichever context was ambient. Spans are now attributed to the request context that owns their trace (captured at root-span start), accumulated per trace, and shipped in a single report when the trace is finalized from its own request's `waitUntil`. The processor also drains the BatchSpanProcessor queue in-context on span end so long runs cannot overflow it, and the exporter retains spans it cannot attribute instead of silently dropping them.

--- a/packages/otel/build.ts
+++ b/packages/otel/build.ts
@@ -6,8 +6,8 @@ const MINIFY = true;
 const SOURCEMAP = true;
 
 const MAX_SIZES = {
-  "dist/node/index.js": 300_000, // Increased from original 217KB limit
-  "dist/edge/index.js": 191_000, // Increased from original 185KB limit
+  "dist/node/index.js": 305_000, // Increased from 300KB for the span-attribution fix (main was within ~2KB of the limit)
+  "dist/edge/index.js": 193_000, // Increased from 191KB for the span-attribution fix (main was within ~100 bytes of the limit)
 };
 
 type ExternalPluginFactory = (external: string[]) => Plugin;

--- a/packages/otel/src/processor/composite-span-processor.test.ts
+++ b/packages/otel/src/processor/composite-span-processor.test.ts
@@ -1,0 +1,179 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type {
+  ReadableSpan,
+  Span,
+  SpanProcessor,
+} from "@opentelemetry/sdk-trace-base";
+import { hrTime } from "@opentelemetry/core";
+import { ROOT_CONTEXT, TraceFlags, SpanKind, SpanStatusCode } from "@opentelemetry/api";
+import { resourceFromAttributes } from "@opentelemetry/resources";
+import type { VercelRequestContext } from "../vercel-request-context/api";
+import { hasVercelRequestContextForTrace } from "../vercel-request-context/api";
+import { CompositeSpanProcessor } from "./composite-span-processor";
+
+const TRACE_ID = "ee75cd9e534ff5e9ed78b4a0c706f0f2";
+const VRC_SYMBOL = Symbol.for("@vercel/request-context");
+type GlobalWithReader = Record<symbol, unknown>;
+
+function installAmbient(ctx: VercelRequestContext | undefined): void {
+  (globalThis as GlobalWithReader)[VRC_SYMBOL] = { get: () => ctx };
+}
+
+function fakeVrc(): VercelRequestContext & {
+  flushes: Array<() => Promise<unknown>>;
+} {
+  const flushes: Array<() => Promise<unknown>> = [];
+  return {
+    flushes,
+    waitUntil: (promiseOrFunc) => {
+      if (typeof promiseOrFunc === "function") {
+        flushes.push(promiseOrFunc as () => Promise<unknown>);
+      }
+    },
+    headers: {},
+    url: "https://example.com",
+    telemetry: { reportSpans: () => undefined },
+  };
+}
+
+function readableSpanFields(spanId: string, parent: boolean) {
+  const spanContext = {
+    traceId: TRACE_ID,
+    spanId,
+    traceFlags: TraceFlags.SAMPLED,
+    isRemote: false,
+  };
+  return {
+    name: `span-${spanId}`,
+    kind: SpanKind.INTERNAL,
+    spanContext: () => spanContext,
+    parentSpanContext: parent
+      ? {
+          spanId: "7e2a325411bdc191",
+          traceId: TRACE_ID,
+          traceFlags: TraceFlags.SAMPLED,
+        }
+      : undefined,
+    startTime: hrTime(1),
+    endTime: hrTime(2),
+    status: { code: SpanStatusCode.UNSET },
+    attributes: {},
+    links: [],
+    events: [],
+    duration: hrTime(1),
+    ended: true,
+    resource: resourceFromAttributes({}),
+    instrumentationScope: { name: "default" },
+    droppedAttributesCount: 0,
+    droppedEventsCount: 0,
+    droppedLinksCount: 0,
+  };
+}
+
+function createRootSpan(spanId: string): Span {
+  return {
+    ...readableSpanFields(spanId, false),
+    setAttribute: () => undefined,
+    setAttributes: () => undefined,
+    addEvent: () => undefined,
+    addLink: () => undefined,
+    addLinks: () => undefined,
+    setStatus: () => undefined,
+    updateName: () => undefined,
+    end: () => undefined,
+    isRecording: () => true,
+    recordException: () => undefined,
+  } as unknown as Span;
+}
+
+function createChildEnd(spanId: string): ReadableSpan {
+  return readableSpanFields(spanId, true) as unknown as ReadableSpan;
+}
+
+function fakeProcessor(): {
+  processor: SpanProcessor;
+  forceFlush: ReturnType<typeof vi.fn>;
+} {
+  const forceFlush = vi.fn().mockResolvedValue(undefined);
+  const processor: SpanProcessor = {
+    onStart: vi.fn(),
+    onEnd: vi.fn(),
+    forceFlush,
+    shutdown: vi.fn().mockResolvedValue(undefined),
+  };
+  return { processor, forceFlush };
+}
+
+describe("CompositeSpanProcessor", () => {
+  afterEach(() => {
+    installAmbient(undefined);
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it("registers the request context for the trace at root start and finalizes it after the final flush", async () => {
+    const vrc = fakeVrc();
+    installAmbient(vrc);
+    const { processor: downstream, forceFlush } = fakeProcessor();
+    const processor = new CompositeSpanProcessor([downstream], undefined);
+
+    const root = createRootSpan("7e2a325411bdc191");
+    processor.onStart(root, ROOT_CONTEXT);
+
+    // The trace's owning context is now captured, independent of the ambient one.
+    installAmbient(undefined);
+    expect(hasVercelRequestContextForTrace(TRACE_ID)).toBe(true);
+
+    // Root ends; the waitUntil-registered final flush drains the processors
+    // and finalizes (ships + unregisters) the trace.
+    processor.onEnd(root as unknown as ReadableSpan);
+    expect(vrc.flushes).toHaveLength(1);
+    await vrc.flushes[0]?.();
+    expect(forceFlush).toHaveBeenCalled();
+    expect(hasVercelRequestContextForTrace(TRACE_ID)).toBe(false);
+  });
+
+  it("flushes in-context once the batch-size threshold of ended spans is reached", () => {
+    installAmbient(fakeVrc());
+    vi.stubEnv("OTEL_BSP_MAX_EXPORT_BATCH_SIZE", "3");
+    const { processor: downstream, forceFlush } = fakeProcessor();
+    const processor = new CompositeSpanProcessor([downstream], undefined);
+
+    processor.onEnd(createChildEnd("0000000000000001"));
+    processor.onEnd(createChildEnd("0000000000000002"));
+    expect(forceFlush).toHaveBeenCalledTimes(0);
+
+    processor.onEnd(createChildEnd("0000000000000003"));
+    expect(forceFlush).toHaveBeenCalledTimes(1);
+  });
+
+  it("flushes in-context once the schedule delay elapses between ended spans", () => {
+    installAmbient(fakeVrc());
+    vi.stubEnv("OTEL_BSP_MAX_EXPORT_BATCH_SIZE", "1000000");
+    vi.stubEnv("OTEL_BSP_SCHEDULE_DELAY", "5000");
+    const { processor: downstream, forceFlush } = fakeProcessor();
+    const processor = new CompositeSpanProcessor([downstream], undefined);
+
+    const now = vi.spyOn(Date, "now");
+    now.mockReturnValue(1000);
+    processor.onEnd(createChildEnd("0000000000000001"));
+    processor.onEnd(createChildEnd("0000000000000002"));
+    expect(forceFlush).toHaveBeenCalledTimes(0);
+
+    now.mockReturnValue(7000);
+    processor.onEnd(createChildEnd("0000000000000003"));
+    expect(forceFlush).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not flush off-Vercel (no request context)", () => {
+    installAmbient(undefined);
+    vi.stubEnv("OTEL_BSP_MAX_EXPORT_BATCH_SIZE", "2");
+    const { processor: downstream, forceFlush } = fakeProcessor();
+    const processor = new CompositeSpanProcessor([downstream], undefined);
+
+    for (let i = 1; i <= 5; i++) {
+      processor.onEnd(createChildEnd(`00000000000000${i}0`));
+    }
+    expect(forceFlush).toHaveBeenCalledTimes(0);
+  });
+});

--- a/packages/otel/src/processor/composite-span-processor.ts
+++ b/packages/otel/src/processor/composite-span-processor.ts
@@ -5,7 +5,12 @@ import type {
   ReadableSpan,
   SpanProcessor,
 } from "@opentelemetry/sdk-trace-base";
-import { getVercelRequestContext } from "../vercel-request-context/api";
+import { getNumberFromEnv } from "@opentelemetry/core";
+import {
+  finalizeTrace,
+  getVercelRequestContext,
+  registerVercelRequestContextForTrace,
+} from "../vercel-request-context/api";
 import { getVercelRequestContextAttributes } from "../vercel-request-context/attributes";
 import { isSampled } from "../util/sampled";
 import type { AttributesFromHeaders } from "../types";
@@ -17,6 +22,13 @@ export class CompositeSpanProcessor implements SpanProcessor {
     { rootSpanId: string; open: Span[] }
   >();
   private readonly waitSpanEnd = new Map<string, () => void>();
+
+  private readonly flushBatchSize =
+    getNumberFromEnv("OTEL_BSP_MAX_EXPORT_BATCH_SIZE") ?? 512;
+  private readonly flushDelayMs =
+    getNumberFromEnv("OTEL_BSP_SCHEDULE_DELAY") ?? 5000;
+  private spansSinceFlush = 0;
+  private lastFlushMs = 0;
 
   constructor(
     private processors: SpanProcessor[],
@@ -58,8 +70,16 @@ export class CompositeSpanProcessor implements SpanProcessor {
         span.setAttributes(vercelRequestContextAttrs);
       }
 
-      // Flush the streams to avoid data loss.
       if (vrc) {
+        // Capture the request context that owns this trace. The exporter
+        // accumulates this trace's spans (mid-run flushes only drain the
+        // BatchSpanProcessor's queue, they don't report) and ships them in a
+        // single report when the trace is finalized below: the runtime only
+        // reliably persists one report per invocation, and only through the
+        // invocation's own telemetry channel.
+        registerVercelRequestContextForTrace(traceId, vrc);
+
+        // Flush the streams to avoid data loss.
         vrc.waitUntil(async () => {
           if (this.rootSpanIds.has(traceId)) {
             // Not root has not completed yet, so no point in flushing.
@@ -81,7 +101,15 @@ export class CompositeSpanProcessor implements SpanProcessor {
               clearTimeout(timer);
             }
           }
-          return this.forceFlush();
+          try {
+            // Drain the processors so every one of this trace's remaining
+            // spans reaches the exporter's per-trace buffer...
+            return await this.forceFlush();
+          } finally {
+            // ...then ship the buffer in one report and drop the captured
+            // context.
+            finalizeTrace(traceId);
+          }
         });
       }
     }
@@ -135,6 +163,33 @@ export class CompositeSpanProcessor implements SpanProcessor {
         this.waitSpanEnd.delete(traceId);
         pending();
       }
+    } else if (sampled && getVercelRequestContext()) {
+      // Periodic drain, Vercel-only. Long-running invocations produce more
+      // spans than the BatchSpanProcessor's queue holds (it silently drops
+      // past maxQueueSize), so drain it regularly into the exporter's
+      // per-trace buffers. Draining doesn't report anything: the trace's
+      // spans ship in a single report at finalizeTrace. Off-Vercel this is
+      // skipped and the stock timer behaves as before. The root span's final
+      // flush is handled by the waitUntil registered in onStart.
+      this.maybeFlush();
+    }
+  }
+
+  private maybeFlush(): void {
+    this.spansSinceFlush += 1;
+    const now = Date.now();
+    if (this.lastFlushMs === 0) {
+      this.lastFlushMs = now;
+    }
+    if (
+      this.spansSinceFlush >= this.flushBatchSize ||
+      now - this.lastFlushMs >= this.flushDelayMs
+    ) {
+      this.spansSinceFlush = 0;
+      this.lastFlushMs = now;
+      void this.forceFlush().catch((e) => {
+        diag.error("@vercel/otel: periodic flush failed:", e);
+      });
     }
   }
 }

--- a/packages/otel/src/vercel-request-context/api.ts
+++ b/packages/otel/src/vercel-request-context/api.ts
@@ -35,3 +35,86 @@ export function getVercelRequestContext(): VercelRequestContext | undefined {
   const reader = (globalThis as GlobalWithReader)[symbol];
   return reader?.get();
 }
+
+/**
+ * Registry of request contexts keyed by trace id, so span exports can be
+ * attributed to the request that OWNS each span instead of whichever request
+ * happens to be ambient at flush time.
+ *
+ * Why this exists: the BatchSpanProcessor's queue is shared by every request
+ * running on the function instance, and its scheduled flush runs in a bare
+ * `setTimeout` OUTSIDE any request's AsyncLocalStorage. The runtime only
+ * reliably persists spans reported through their own invocation's
+ * `telemetry.reportSpans` channel, and only ONE report per invocation is
+ * dependable (mid-run reports have been observed not to land). Long-running
+ * invocations, e.g. Vercel Workflows, used to lose every span that was
+ * flushed mid-run: their traces looked blank except for the last few seconds.
+ *
+ * The context is captured per trace while inside the owning request (root
+ * span `onStart`), spans for registered traces are accumulated by the
+ * exporter, and the trace's whole buffer is shipped in a single report by
+ * `finalizeTrace` (invoked from the request's `waitUntil`, after the final
+ * flush). A hard cap bounds the registry against traces whose root span
+ * never ends.
+ */
+const traceContextRegistry = new Map<string, VercelRequestContext>();
+
+const MAX_REGISTRY_SIZE = 1024;
+
+type TraceFinalizer = (traceId: string) => void;
+
+/** Callbacks (e.g. the runtime span exporter) shipping a trace's buffer. */
+const traceFinalizers = new Set<TraceFinalizer>();
+
+/** @internal Register a callback invoked when a trace is finalized. */
+export function onTraceFinalize(finalizer: TraceFinalizer): void {
+  traceFinalizers.add(finalizer);
+}
+
+/** @internal Capture the request context that owns a given trace. */
+export function registerVercelRequestContextForTrace(
+  traceId: string,
+  context: VercelRequestContext,
+): void {
+  if (
+    traceContextRegistry.size >= MAX_REGISTRY_SIZE &&
+    !traceContextRegistry.has(traceId)
+  ) {
+    // Evict the oldest entry (Map preserves insertion order) so a leak of
+    // never-ending traces cannot grow the registry unboundedly.
+    const oldest: string | undefined = traceContextRegistry.keys().next()
+      .value as string | undefined;
+    if (oldest !== undefined) {
+      traceContextRegistry.delete(oldest);
+    }
+  }
+  traceContextRegistry.set(traceId, context);
+}
+
+/** @internal Whether a trace has a captured owning context. */
+export function hasVercelRequestContextForTrace(traceId: string): boolean {
+  return traceContextRegistry.has(traceId);
+}
+
+/** @internal Resolve the request context that owns a trace. */
+export function getVercelRequestContextForTrace(
+  traceId: string,
+): VercelRequestContext | undefined {
+  return traceContextRegistry.get(traceId);
+}
+
+/**
+ * @internal Ship a trace's accumulated spans (via the registered finalizers)
+ * and drop its captured context. Called from the owning request's
+ * `waitUntil` after the final flush, so the single report this produces is
+ * sent while the invocation is still able to deliver telemetry.
+ */
+export function finalizeTrace(traceId: string): void {
+  try {
+    for (const finalizer of traceFinalizers) {
+      finalizer(traceId);
+    }
+  } finally {
+    traceContextRegistry.delete(traceId);
+  }
+}

--- a/packages/otel/src/vercel-request-context/exporter.test.ts
+++ b/packages/otel/src/vercel-request-context/exporter.test.ts
@@ -1,0 +1,190 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ReadableSpan } from "@opentelemetry/sdk-trace-base";
+import { ExportResultCode, hrTime } from "@opentelemetry/core";
+import { TraceFlags, SpanKind, SpanStatusCode } from "@opentelemetry/api";
+import type { IExportTraceServiceRequest } from "@opentelemetry/otlp-transformer/build/src/trace/internal-types";
+import { resourceFromAttributes } from "@opentelemetry/resources";
+import type { VercelRequestContext } from "./api";
+import { finalizeTrace, registerVercelRequestContextForTrace } from "./api";
+import { VercelRuntimeSpanExporter } from "./exporter";
+
+const TRACE_A = "aa75cd9e534ff5e9ed78b4a0c706f0f2";
+const TRACE_B = "bb75cd9e534ff5e9ed78b4a0c706f0f2";
+const VRC_SYMBOL = Symbol.for("@vercel/request-context");
+
+type GlobalWithReader = Record<symbol, unknown>;
+
+function createSpan(spanId: string, traceId = TRACE_A): ReadableSpan {
+  const spanContext = {
+    traceId,
+    spanId,
+    traceFlags: TraceFlags.SAMPLED,
+    isRemote: false,
+  };
+  return {
+    name: `span-${spanId}`,
+    kind: SpanKind.INTERNAL,
+    spanContext: () => spanContext,
+    parentSpanContext: undefined,
+    startTime: hrTime(1),
+    endTime: hrTime(2),
+    status: { code: SpanStatusCode.UNSET },
+    attributes: {},
+    links: [],
+    events: [],
+    duration: hrTime(1),
+    ended: true,
+    resource: resourceFromAttributes({}),
+    instrumentationScope: { name: "default" },
+    droppedAttributesCount: 0,
+    droppedEventsCount: 0,
+    droppedLinksCount: 0,
+  };
+}
+
+function makeContext(): {
+  ctx: VercelRequestContext;
+  reportSpans: ReturnType<typeof vi.fn>;
+} {
+  const reportSpans = vi.fn();
+  const ctx: VercelRequestContext = {
+    waitUntil: () => undefined,
+    headers: {},
+    url: "https://example.com",
+    telemetry: { reportSpans },
+  };
+  return { ctx, reportSpans };
+}
+
+function installAmbient(ctx: VercelRequestContext | undefined): void {
+  (globalThis as GlobalWithReader)[VRC_SYMBOL] = { get: () => ctx };
+}
+
+function shippedSpanIds(
+  reportSpans: ReturnType<typeof vi.fn>,
+  call = 0,
+): string[] {
+  const data = reportSpans.mock.calls[call]?.[0] as IExportTraceServiceRequest;
+  return (data.resourceSpans ?? []).flatMap((rs) =>
+    rs.scopeSpans.flatMap((ss) =>
+      (ss.spans ?? []).map((s) => String(s.spanId)),
+    ),
+  );
+}
+
+describe("VercelRuntimeSpanExporter", () => {
+  afterEach(() => {
+    installAmbient(undefined);
+    // Clear any registrations left behind by a test.
+    finalizeTrace(TRACE_A);
+    finalizeTrace(TRACE_B);
+    vi.restoreAllMocks();
+  });
+
+  it("accumulates spans of a registered trace and ships them once, through the owning context, at finalizeTrace", () => {
+    const owner = makeContext();
+    const ambient = makeContext();
+    registerVercelRequestContextForTrace(TRACE_A, owner.ctx);
+    installAmbient(ambient.ctx);
+
+    const exporter = new VercelRuntimeSpanExporter();
+    const result = vi.fn();
+    // Two mid-run flushes: nothing must be reported yet.
+    exporter.export([createSpan("0000000000000001", TRACE_A)], result);
+    exporter.export([createSpan("0000000000000002", TRACE_A)], result);
+    expect(result).toHaveBeenCalledWith({
+      code: ExportResultCode.SUCCESS,
+      error: undefined,
+    });
+    expect(owner.reportSpans).toHaveBeenCalledTimes(0);
+    expect(ambient.reportSpans).toHaveBeenCalledTimes(0);
+
+    // Finalize: exactly ONE report, through the owner, with all spans.
+    finalizeTrace(TRACE_A);
+    expect(owner.reportSpans).toHaveBeenCalledTimes(1);
+    expect(ambient.reportSpans).toHaveBeenCalledTimes(0);
+    expect(shippedSpanIds(owner.reportSpans)).toHaveLength(2);
+
+    // Finalizing again reports nothing further.
+    finalizeTrace(TRACE_A);
+    expect(owner.reportSpans).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps concurrent traces separate: each finalize ships only its own spans", () => {
+    const ownerA = makeContext();
+    const ownerB = makeContext();
+    registerVercelRequestContextForTrace(TRACE_A, ownerA.ctx);
+    registerVercelRequestContextForTrace(TRACE_B, ownerB.ctx);
+
+    const exporter = new VercelRuntimeSpanExporter();
+    exporter.export(
+      [
+        createSpan("0000000000000001", TRACE_A),
+        createSpan("0000000000000002", TRACE_B),
+        createSpan("0000000000000003", TRACE_A),
+      ],
+      vi.fn(),
+    );
+
+    finalizeTrace(TRACE_A);
+    expect(ownerA.reportSpans).toHaveBeenCalledTimes(1);
+    expect(shippedSpanIds(ownerA.reportSpans)).toHaveLength(2);
+    expect(ownerB.reportSpans).toHaveBeenCalledTimes(0);
+
+    finalizeTrace(TRACE_B);
+    expect(ownerB.reportSpans).toHaveBeenCalledTimes(1);
+    expect(shippedSpanIds(ownerB.reportSpans)).toHaveLength(1);
+  });
+
+  it("ships spans of untracked traces immediately through the ambient context", () => {
+    const ambient = makeContext();
+    installAmbient(ambient.ctx);
+
+    const exporter = new VercelRuntimeSpanExporter();
+    exporter.export([createSpan("0000000000000001", TRACE_B)], vi.fn());
+
+    expect(ambient.reportSpans).toHaveBeenCalledTimes(1);
+    expect(shippedSpanIds(ambient.reportSpans)).toHaveLength(1);
+  });
+
+  it("retains unattributable spans and re-attempts them on a later flush", () => {
+    const exporter = new VercelRuntimeSpanExporter();
+
+    installAmbient(undefined);
+    const firstResult = vi.fn();
+    exporter.export([createSpan("0000000000000001", TRACE_B)], firstResult);
+    expect(firstResult).toHaveBeenCalledWith({
+      code: ExportResultCode.SUCCESS,
+      error: undefined,
+    });
+
+    const { ctx, reportSpans } = makeContext();
+    installAmbient(ctx);
+    exporter.export([createSpan("0000000000000002", TRACE_B)], vi.fn());
+
+    // Retained + incoming ship together via the now-available ambient context.
+    expect(reportSpans).toHaveBeenCalledTimes(1);
+    expect(shippedSpanIds(reportSpans)).toHaveLength(2);
+  });
+
+  it("retains a finalized trace's spans when its context fails, without losing them", () => {
+    const failing = makeContext();
+    failing.reportSpans.mockImplementation(() => {
+      throw new Error("boom");
+    });
+    registerVercelRequestContextForTrace(TRACE_A, failing.ctx);
+    installAmbient(undefined);
+
+    const exporter = new VercelRuntimeSpanExporter();
+    exporter.export([createSpan("0000000000000001", TRACE_A)], vi.fn());
+    finalizeTrace(TRACE_A);
+    expect(failing.reportSpans).toHaveBeenCalledTimes(1);
+
+    // The retained spans ship on the next flush that has a working context.
+    const healthy = makeContext();
+    installAmbient(healthy.ctx);
+    exporter.export([], vi.fn());
+    expect(healthy.reportSpans).toHaveBeenCalledTimes(1);
+    expect(shippedSpanIds(healthy.reportSpans)).toHaveLength(1);
+  });
+});

--- a/packages/otel/src/vercel-request-context/exporter.ts
+++ b/packages/otel/src/vercel-request-context/exporter.ts
@@ -3,38 +3,163 @@ import type { ReadableSpan, SpanExporter } from "@opentelemetry/sdk-trace-base";
 import { ExportResultCode, type ExportResult } from "@opentelemetry/core";
 import { JsonTraceSerializer } from "@opentelemetry/otlp-transformer/build/src/trace/json/trace";
 import type { IExportTraceServiceRequest } from "@opentelemetry/otlp-transformer/build/src/trace/internal-types";
-import { getVercelRequestContext } from "./api";
+import {
+  getVercelRequestContext,
+  getVercelRequestContextForTrace,
+  hasVercelRequestContextForTrace,
+  onTraceFinalize,
+  type VercelRequestContext,
+} from "./api";
 
+/**
+ * Upper bound on spans accumulated per trace while its invocation runs.
+ * A long-running invocation (e.g. a Vercel Workflow) can produce thousands
+ * of spans; when the cap is hit the oldest spans are dropped with a warning
+ * rather than growing memory unboundedly.
+ */
+const MAX_TRACE_BUFFER_SIZE = 8192;
+
+/**
+ * Ships spans to the Vercel runtime's telemetry channel.
+ *
+ * The runtime only reliably persists ONE `reportSpans` payload per
+ * invocation, and only when reported through that invocation's own request
+ * context. So instead of shipping every batch as it is flushed (which loses
+ * every mid-run batch of a long invocation, and mis-routes spans of
+ * concurrent requests sharing the BatchSpanProcessor queue), this exporter:
+ *
+ * - ACCUMULATES spans whose trace has a captured owning context (see
+ *   `registerVercelRequestContextForTrace`) into a per-trace buffer, and
+ *   ships the whole buffer in a single report when the trace is finalized
+ *   from its own request's `waitUntil` (see `finalizeTrace`).
+ * - Ships spans of untracked traces immediately through the ambient request
+ *   context, preserving the previous behavior for spans created outside any
+ *   instrumented request.
+ * - Retains spans it cannot attribute at all and re-attempts them on the
+ *   next flush, instead of silently acking and dropping them.
+ */
 export class VercelRuntimeSpanExporter implements SpanExporter {
+  private readonly traceBuffers = new Map<string, ReadableSpan[]>();
+  private pendingSpans: ReadableSpan[] = [];
+  private droppedSpansCount = 0;
+
+  constructor() {
+    onTraceFinalize((traceId) => this.shipTrace(traceId));
+  }
+
   export(
     spans: ReadableSpan[],
     resultCallback: (result: ExportResult) => void,
   ): void {
-    const context = getVercelRequestContext();
-    if (!context?.telemetry) {
-      diag.warn("@vercel/otel: no telemetry context found");
-      resultCallback({ code: ExportResultCode.SUCCESS, error: undefined });
-      return;
+    const immediate = new Map<VercelRequestContext, ReadableSpan[]>();
+    const unattributable: ReadableSpan[] = [];
+
+    // Previously-retained spans get another attribution attempt first.
+    const candidates =
+      this.pendingSpans.length > 0 ? [...this.pendingSpans, ...spans] : spans;
+    this.pendingSpans = [];
+
+    for (const span of candidates) {
+      const traceId = span.spanContext().traceId;
+      if (hasVercelRequestContextForTrace(traceId)) {
+        this.bufferForTrace(traceId, span);
+        continue;
+      }
+      const ambient = getVercelRequestContext();
+      if (ambient?.telemetry) {
+        const group = immediate.get(ambient);
+        if (group) {
+          group.push(span);
+        } else {
+          immediate.set(ambient, [span]);
+        }
+        continue;
+      }
+      unattributable.push(span);
+    }
+
+    if (unattributable.length > 0) {
+      // No owning or ambient context (e.g. a bare-setTimeout timer flush for
+      // an untracked trace). Retain and re-attempt on the next flush instead
+      // of silently dropping.
+      diag.debug(
+        `@vercel/otel: no telemetry context for ${unattributable.length} span(s); retaining for the next flush`,
+      );
+      this.retain(unattributable);
     }
 
     try {
-      const serializedData = JsonTraceSerializer.serializeRequest(spans);
-
-      if (!serializedData) {
-        throw new Error("Failed to serialize spans");
-      }
-      // Convert back to object format for the Vercel telemetry API
-      const data = JSON.parse(
-        new TextDecoder().decode(serializedData),
-      ) as IExportTraceServiceRequest;
-
-      context.telemetry.reportSpans(data);
+      immediate.forEach((contextSpans, context) => {
+        try {
+          reportSpans(context.telemetry, contextSpans);
+        } catch (e) {
+          this.retain(contextSpans);
+          diag.warn("@vercel/otel: failed to report spans, retained:", e);
+        }
+      });
       resultCallback({ code: ExportResultCode.SUCCESS, error: undefined });
     } catch (e) {
       resultCallback({
         code: ExportResultCode.FAILED,
         error: e instanceof Error ? e : new Error(String(e)),
       });
+    }
+  }
+
+  /**
+   * Ship a trace's accumulated spans in a single report through the context
+   * that owns the trace. Invoked via `finalizeTrace` from the owning
+   * request's `waitUntil`, after the final flush drained the processor.
+   */
+  private shipTrace(traceId: string): void {
+    const spans = this.traceBuffers.get(traceId);
+    this.traceBuffers.delete(traceId);
+    if (!spans || spans.length === 0) {
+      return;
+    }
+    const context =
+      getVercelRequestContextForTrace(traceId) ?? getVercelRequestContext();
+    if (!context?.telemetry) {
+      diag.warn(
+        `@vercel/otel: no telemetry context to finalize trace ${traceId}; retaining ${spans.length} span(s)`,
+      );
+      this.retain(spans);
+      return;
+    }
+    try {
+      reportSpans(context.telemetry, spans);
+    } catch (e) {
+      this.retain(spans);
+      diag.warn("@vercel/otel: failed to report finalized trace, retained:", e);
+    }
+  }
+
+  private bufferForTrace(traceId: string, span: ReadableSpan): void {
+    let buffer = this.traceBuffers.get(traceId);
+    if (!buffer) {
+      buffer = [];
+      this.traceBuffers.set(traceId, buffer);
+    }
+    buffer.push(span);
+    const overflow = buffer.length - MAX_TRACE_BUFFER_SIZE;
+    if (overflow > 0) {
+      buffer.splice(0, overflow);
+      this.droppedSpansCount += overflow;
+      diag.warn(
+        `@vercel/otel: trace span buffer full, dropped ${this.droppedSpansCount} span(s) total`,
+      );
+    }
+  }
+
+  private retain(spans: ReadableSpan[]): void {
+    this.pendingSpans.push(...spans);
+    const overflow = this.pendingSpans.length - MAX_TRACE_BUFFER_SIZE;
+    if (overflow > 0) {
+      this.pendingSpans.splice(0, overflow);
+      this.droppedSpansCount += overflow;
+      diag.warn(
+        `@vercel/otel: retained span buffer full, dropped ${this.droppedSpansCount} span(s) total`,
+      );
     }
   }
 
@@ -45,4 +170,22 @@ export class VercelRuntimeSpanExporter implements SpanExporter {
   forceFlush?(): Promise<void> {
     return Promise.resolve();
   }
+}
+
+function reportSpans(
+  telemetry: NonNullable<VercelRequestContext["telemetry"]> | undefined,
+  spans: ReadableSpan[],
+): void {
+  if (!telemetry) {
+    throw new Error("no telemetry channel");
+  }
+  const serializedData = JsonTraceSerializer.serializeRequest(spans);
+  if (!serializedData) {
+    throw new Error("Failed to serialize spans");
+  }
+  // Convert back to object format for the Vercel telemetry API
+  const data = JSON.parse(
+    new TextDecoder().decode(serializedData),
+  ) as IExportTraceServiceRequest;
+  telemetry.reportSpans(data);
 }


### PR DESCRIPTION
## Problem

Traces from long-running invocations (e.g. Vercel Workflows) are missing most spans from the first part of the run: the trace looks blank early on, with all step spans bunched into the last few seconds. The work happens the whole time; the spans are genuinely lost.

## Root cause (client side)

1. The `BatchSpanProcessor` schedules flushes with a bare `setTimeout`, which runs outside the request's `AsyncLocalStorage`. The runtime exporter then resolves no request context and silently acked + dropped every mid-run batch. Only the final flush, triggered via `waitUntil` (in-context), survived.
2. The `BatchSpanProcessor` queue is shared by all concurrent requests on an instance, so a flush ships other invocations' spans through the wrong request's telemetry channel, where they are not reliably persisted.

## Fix

- Capture the owning request context per trace id at root-span start (always in-request), bounded against never-ending traces.
- The exporter accumulates spans of registered traces per trace and ships the whole buffer in a single report when the trace is finalized from its own request's `waitUntil`. Untracked traces keep shipping immediately through the ambient context.
- Spans that cannot be attributed are retained and re-attempted instead of silently acked.
- The processor drains the `BatchSpanProcessor` queue in-context on span end (debounced on `OTEL_BSP_MAX_EXPORT_BATCH_SIZE` / `OTEL_BSP_SCHEDULE_DELAY`) so long runs cannot overflow `maxQueueSize`. Off-Vercel behavior is unchanged.

Verified on a long-running workflow reproduction: with this change all step spans consistently survive across repeated runs (previously only the last few seconds' spans did).

## Relationship to #213

Same problem; this PR keeps its in-context flush and retain-instead-of-drop ideas, and adds per-trace attribution + single-report delivery, which testing showed is required for reliability on warm instances.

## Testing

- Unit tests for accumulation/finalize semantics, per-trace separation, retain/re-ship paths, in-context drain triggers, and registration lifecycle.
- `type-check`, `eslint`, full unit suite pass. Bundle size limits bumped slightly (main was within ~2KB / ~100 bytes of them).
